### PR TITLE
Fix ghost at origin: parent tool ghost to gizmo

### DIFF
--- a/src/ada_mj/console.py
+++ b/src/ada_mj/console.py
@@ -99,26 +99,29 @@ IPython:
 
         all_panels = []
 
-        # Fix teleop ghost — the generic console creates it with empty prefix
-        # (shows full robot). Replace with tool prefix so only the fork shows.
+        # Add ghost hand for the tool — the generic console skips ghost
+        # creation when there's no gripper (ADA has no gripper, just a
+        # welded tool). Create the ghost here with the tool body prefix,
+        # parented to the gizmo so it moves with it.
         tool_prefix = ""
         if robot.config.tool == "articutool":
             tool_prefix = "articutool/"
         elif robot.config.tool == "forque":
             tool_prefix = "forque/"
         if tool_prefix:
-            for panel in viewer._panels:
-                if hasattr(panel, "_ghost") and panel._ghost is not None:
-                    panel._ghost.remove()
-                    from mj_viser.teleop_panel import GhostHand
+            from mj_viser.teleop_panel import GhostHand
 
-                    panel._ghost = GhostHand(
-                        viewer._server,
-                        robot.model,
-                        robot.data,
-                        gripper_body_prefix=tool_prefix,
-                        ee_site_id=robot.arm.ee_site_id,
-                    )
+            for panel in viewer._panels:
+                if not hasattr(panel, "_gizmo") or panel._gizmo is None:
+                    continue
+                panel._ghost = GhostHand(
+                    viewer._server,
+                    robot.model,
+                    robot.data,
+                    gripper_body_prefix=tool_prefix,
+                    ee_site_id=robot.arm.ee_site_id,
+                    name=f"{panel._gizmo.name}/ghost",
+                )
 
         with tabs.add_tab("ADA"):
             # Keyframe dropdown


### PR DESCRIPTION
## Summary

- Ghost hand was stuck at world origin because the replacement code used the default scene name instead of parenting it to the gizmo
- Root cause: the generic console created a ghost with empty `gripper_body_prefix` (ADA has no gripper), which matched every body in the model
- Fix spans 3 repos:
  - **mj_viser**: `enable_ghost` flag on TeleopPanel — skips ghost on empty prefix
  - **mj_manipulator**: console passes `enable_ghost=False` when no gripper
  - **ada_mj**: panel_setup creates the ghost with tool prefix, parented to gizmo

## Test plan

- [ ] `uv run python -m ada_mj --viser --physics`
- [ ] Activate teleop — ghost fork should appear at the EE, not at origin
- [ ] Drag gizmo — ghost should move with it
- [ ] Ghost color: green=tracking, orange=collision, red=unreachable

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)