### PR TITLE
Feeding scene: ForkTSR + table demo scene with StablePlacer plate and food

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,16 @@ dependencies = [
     "ada-assets @ git+https://github.com/personalrobotics/ada_assets.git",
     "mj-manipulator @ git+https://github.com/personalrobotics/mj_manipulator.git",
     "mj-environment @ git+https://github.com/personalrobotics/mj_environment.git",
+    "prl-assets @ git+https://github.com/personalrobotics/prl_assets.git",
+    "tsr @ git+https://github.com/personalrobotics/tsr.git",
 ]
 
 [tool.uv.sources]
 ada-assets = { workspace = true }
 mj-manipulator = { workspace = true }
 mj-environment = { workspace = true }
+prl-assets = { workspace = true }
+tsr = { workspace = true }
 
 [project.optional-dependencies]
 dev = [

--- a/src/ada_mj/config.py
+++ b/src/ada_mj/config.py
@@ -91,6 +91,11 @@ class ADAConfig:
     with_human: bool = True
     with_camera: bool = True
 
+    # Demo scene — extends the bare robot with task-specific furniture/objects.
+    # Currently supported: "none" (just the robot), "table" (over-bed table +
+    # plate of food for the feeding demo).
+    scene: str = "table"
+
     # End-effector site — must be on the arm's kinematic chain (link_6),
     # not on the tool (freejoint body). IK can only move arm joints.
     ee_site: str = "ee_site"
@@ -115,4 +120,4 @@ class ADAConfig:
     @classmethod
     def bare(cls) -> ADAConfig:
         """Config with no tool, no camera, no human (just arm on wheelchair)."""
-        return cls(tool=None, with_camera=False, with_human=False)
+        return cls(tool=None, with_camera=False, with_human=False, scene="none")

--- a/src/ada_mj/feeding/fork_tsr.py
+++ b/src/ada_mj/feeding/fork_tsr.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Fork tool TSR generator for ADA feeding.
+
+Generates TSRTemplates for fork-related tasks:
+- ``above_plate``: fork tip hovering above the plate surface
+- ``approach_mouth``: fork tip approaching the mouth from the front
+
+The TSRs constrain the fork TIP position/orientation relative to
+the plate or mouth. ``Tw_e`` bakes in the inverse of ``T_ee_to_tip``
+so the planner gets EE targets (what it needs for IK).
+
+This is ADA-specific (lives in ada_mj, not the tsr repo).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tsr.template import TSRTemplate
+
+if TYPE_CHECKING:
+    import mujoco
+
+
+class ForkTSR:
+    """Generate TSR templates for fork-based manipulation.
+
+    Reads the EE-to-fork-tip transform live from the MuJoCo model
+    (not cached) because the articutool joints change the relationship.
+
+    Args:
+        model: MuJoCo model.
+        data: MuJoCo data.
+        ee_site_name: Name of the EE site (on the arm kinematic chain).
+        tip_site_name: Name of the fork tip site.
+    """
+
+    def __init__(
+        self,
+        model: mujoco.MjModel,
+        data: mujoco.MjData,
+        ee_site_name: str = "ee_site",
+        tip_site_name: str = "articutool/fork_tip",
+    ):
+        import mujoco as mj
+
+        self._model = model
+        self._data = data
+        self._ee_site_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_SITE, ee_site_name)
+        self._tip_site_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_SITE, tip_site_name)
+
+        if self._ee_site_id < 0:
+            raise ValueError(f"EE site '{ee_site_name}' not found")
+        if self._tip_site_id < 0:
+            raise ValueError(f"Fork tip site '{tip_site_name}' not found")
+
+    def _get_T_ee_to_tip(self) -> np.ndarray:
+        """Compute the current EE-to-fork-tip transform from the model.
+
+        Must be called after mj_forward so site poses are up to date.
+        The transform changes with articutool joint angles.
+        """
+        T_world_ee = self._site_pose(self._ee_site_id)
+        T_world_tip = self._site_pose(self._tip_site_id)
+        return np.linalg.inv(T_world_ee) @ T_world_tip
+
+    def _site_pose(self, site_id: int) -> np.ndarray:
+        """Read a 4x4 pose from a MuJoCo site."""
+        T = np.eye(4)
+        T[:3, :3] = self._data.site_xmat[site_id].reshape(3, 3)
+        T[:3, 3] = self._data.site_xpos[site_id]
+        return T
+
+    def above_plate(
+        self,
+        plate_radius: float,
+        hover_height: float = 0.03,
+        *,
+        k: int = 3,
+    ) -> list[TSRTemplate]:
+        """TSR templates for fork tip hovering above a plate.
+
+        The plate frame has z pointing up and origin at the plate center
+        surface. The fork tip should point downward (into the food).
+
+        Freedoms:
+        - x, y: free within plate radius (any position on plate)
+        - z: fixed at hover_height above plate surface
+        - yaw: free (any approach angle)
+        - roll, pitch: constrained (fork tip must point down)
+
+        The planner samples from these templates to find a collision-free
+        configuration with the fork above the plate.
+
+        Args:
+            plate_radius: Radius of the plate (meters).
+            hover_height: Height above plate surface (meters).
+            k: Number of depth levels to generate.
+
+        Returns:
+            List of TSRTemplates. Instantiate with the plate's world pose.
+        """
+        import mujoco
+
+        mujoco.mj_forward(self._model, self._data)
+        T_ee_tip = self._get_T_ee_to_tip()
+
+        # TSR frame: at plate surface, z-up.
+        # Fork tip should be at z=hover_height, pointing down (-z).
+        # Tw_e maps from TSR frame (plate) to EE: tip_pose → EE_pose.
+        #
+        # At Bw=0 the fork tip is at [0, 0, hover_height] in plate frame,
+        # pointing down. Tw_e = T_tip_to_ee at this canonical pose.
+
+        # Fork tip pointing down means tip z-axis = [0, 0, -1] in plate frame.
+        # Construct T_plate_to_tip_canonical:
+        T_plate_tip = np.eye(4)
+        T_plate_tip[2, 3] = hover_height
+        # Rotate tip frame so its z-axis points down (180° about x)
+        T_plate_tip[:3, :3] = np.array(
+            [
+                [1, 0, 0],
+                [0, -1, 0],
+                [0, 0, -1],
+            ]
+        )
+
+        # T_tip_to_ee: inverse of T_ee_to_tip, used to compose Tw_e per height
+        T_tip_ee = np.linalg.inv(T_ee_tip)
+
+        # Bounds: x/y free on plate, z fixed, yaw free
+        Bw = np.array(
+            [
+                [-plate_radius, plate_radius],  # x: slide on plate
+                [-plate_radius, plate_radius],  # y: slide on plate
+                [0.0, 0.0],  # z: fixed at hover_height
+                [0.0, 0.0],  # roll: fixed
+                [0.0, 0.0],  # pitch: fixed
+                [-np.pi, np.pi],  # yaw: any approach angle
+            ]
+        )
+
+        templates = []
+        heights = np.linspace(hover_height, hover_height + 0.05, max(k, 1))
+        for i, h in enumerate(heights):
+            T_plate_tip_h = T_plate_tip.copy()
+            T_plate_tip_h[2, 3] = h
+            Tw_e_h = T_plate_tip_h @ T_tip_ee
+
+            templates.append(
+                TSRTemplate(
+                    T_ref_tsr=np.eye(4),
+                    Tw_e=Tw_e_h,
+                    Bw=Bw,
+                    task="above",
+                    subject="fork_tip",
+                    reference="plate",
+                    name=f"Fork above plate — {h * 100:.0f}cm",
+                    description=f"Fork tip {h * 100:.1f}cm above plate, "
+                    f"x/y free within {plate_radius * 100:.0f}cm radius, "
+                    f"yaw free",
+                )
+            )
+
+        return templates
+
+    def approach_mouth(
+        self,
+        approach_distance: float = 0.05,
+        *,
+        k: int = 3,
+    ) -> list[TSRTemplate]:
+        """TSR templates for fork tip approaching the mouth.
+
+        The mouth frame has +x pointing forward (out of the mouth).
+        The fork should approach along -x (toward the mouth), with
+        the tip approximately horizontal.
+
+        Freedoms:
+        - x: at approach_distance from mouth (offset along +x)
+        - y, z: small freedom (±2cm) for head position uncertainty
+        - yaw: small freedom (±30°) for approach angle variation
+        - roll, pitch: small freedom (±15°) for fork tilt
+
+        Args:
+            approach_distance: How far from mouth to position the fork tip.
+            k: Number of offset levels.
+
+        Returns:
+            List of TSRTemplates. Instantiate with the mouth's world pose.
+        """
+        import mujoco
+
+        mujoco.mj_forward(self._model, self._data)
+        T_ee_tip = self._get_T_ee_to_tip()
+        T_tip_ee = np.linalg.inv(T_ee_tip)
+
+        # Fork tip at [approach_distance, 0, 0] in mouth frame,
+        # approaching along -x (mouth's +x = forward out of face).
+        # Fork tip z-axis should point along -x of mouth frame (toward mouth).
+        T_mouth_tip = np.eye(4)
+        T_mouth_tip[0, 3] = approach_distance  # offset along mouth +x
+        # Rotate tip frame so its z-axis = mouth -x (approaching mouth)
+        T_mouth_tip[:3, :3] = np.array(
+            [
+                [0, 0, 1],  # tip x = mouth z (up)
+                [0, 1, 0],  # tip y = mouth y (left)
+                [-1, 0, 0],  # tip z = mouth -x (toward mouth)
+            ]
+        )
+
+        # Bounds: position tight, orientation has some freedom
+        Bw = np.array(
+            [
+                [0.0, 0.0],  # x: fixed at approach distance
+                [-0.02, 0.02],  # y: ±2cm lateral
+                [-0.02, 0.02],  # z: ±2cm vertical
+                [-np.radians(15), np.radians(15)],  # roll: ±15°
+                [-np.radians(15), np.radians(15)],  # pitch: ±15°
+                [-np.radians(30), np.radians(30)],  # yaw: ±30°
+            ]
+        )
+
+        templates = []
+        distances = np.linspace(approach_distance, approach_distance + 0.05, max(k, 1))
+        for i, d in enumerate(distances):
+            T_mouth_tip_d = T_mouth_tip.copy()
+            T_mouth_tip_d[0, 3] = d
+            Tw_e_d = T_mouth_tip_d @ T_tip_ee
+
+            templates.append(
+                TSRTemplate(
+                    T_ref_tsr=np.eye(4),
+                    Tw_e=Tw_e_d,
+                    Bw=Bw,
+                    task="approach",
+                    subject="fork_tip",
+                    reference="mouth",
+                    name=f"Fork toward mouth — {d * 100:.0f}cm",
+                    description=f"Fork tip {d * 100:.1f}cm from mouth along approach axis, "
+                    f"y/z ±2cm, yaw ±30°, roll/pitch ±15°",
+                )
+            )
+
+        return templates

--- a/src/ada_mj/robot.py
+++ b/src/ada_mj/robot.py
@@ -190,15 +190,23 @@ class ADA:
     # -- Model building -------------------------------------------------------
 
     def _build_model(self) -> tuple[mujoco.MjModel, mujoco.MjData]:
-        """Build the MuJoCo model from ada_assets."""
-        from ada_assets.assembly import assemble_ada
-
-        return assemble_ada(
+        """Build the MuJoCo model — base ADA robot plus the configured demo scene."""
+        kwargs = dict(
             tool=self.config.tool,
             tool_tip=self.config.tool_tip,
             with_human=self.config.with_human,
             with_camera=self.config.with_camera,
         )
+        scene = self.config.scene
+        if scene == "none":
+            from ada_assets.assembly import assemble_ada
+
+            return assemble_ada(**kwargs)
+        if scene == "table":
+            from ada_mj.scenes import assemble_table_demo
+
+            return assemble_table_demo(**kwargs)
+        raise ValueError(f"Unknown scene '{self.config.scene}'. Available: 'none', 'table'.")
 
     # -- Core access ----------------------------------------------------------
 

--- a/src/ada_mj/scenes/__init__.py
+++ b/src/ada_mj/scenes/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Demo scenes for ADA.
+
+Each scene composes the base ADA robot (from ada_assets) with task-specific
+furniture and objects (table, plate, food; bedside tray; etc.).
+"""
+
+from ada_mj.scenes.table import assemble_table_demo
+
+__all__ = ["assemble_table_demo"]

--- a/src/ada_mj/scenes/table.py
+++ b/src/ada_mj/scenes/table.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Table demo: ADA + hospital over-bed table + plate + food items.
+
+Composition:
+- Base robot (wheelchair + JACO2 + articutool + human) from ada_assets
+- ``ada_table`` from prl_assets, positioned in front of the user using the
+  ada_feeding planning-scene pose
+- ``plastic_plate`` from prl_assets, placed on the table via a StablePlacer
+  TSR (canonical upright placement at the table center)
+- N small bite-sized food cylinders as freejoint objects on the plate
+
+The plate is a static body (no joint) — it stays put for the demo. Food
+items are freejoint so the fork can stab and lift them.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import mujoco
+
+from ada_assets.assembly import build_spec, compile_and_init
+from prl_assets import OBJECTS_DIR
+from tsr.placement.stable_placer import StablePlacer
+
+
+# Table position in the wheelchair/world frame. x and y are derived from
+# the ada_feeding planning scene (config: ada_planning_scene.yaml, namespace
+# "seated"): table at [0.08, -0.5, -0.56] in the `root` (arm-base) frame,
+# with arm-base at world [-0.02, 0.02, 0.5112]. z is forced to 0 so the
+# cart rests on the visible world floor (our wheelchair model's arm-base
+# height differs by ~5 cm from ada_feeding's calibration; following their
+# z literally would sink the cart below our floor).
+TABLE_POS = np.array([0.06, -0.48, 0.0])
+TABLE_QUAT = np.array([1.0, 0.0, 0.0, 0.0])  # identity (wxyz)
+TABLE_SURFACE_HEIGHT = 0.735  # from prl_assets/ada_table/meta.yaml
+
+# Plastic plate dimensions (prl_assets/plastic_plate/meta.yaml)
+PLATE_RADIUS = 0.133
+PLATE_HEIGHT = 0.027
+
+# Usable half-extents of the table surface for placement sampling.
+# The table mesh is 1.85 × 0.74 m but the C-shape leaves a smaller usable
+# rectangle near the user. Conservative half-extents keep the plate centered.
+TABLE_PLACEMENT_X = 0.20
+TABLE_PLACEMENT_Y = 0.15
+
+# Default food primitives (small bite-sized cylinders)
+DEFAULT_FOOD = [
+    # (label, radius, height, rgba)
+    ("strawberry", 0.013, 0.022, (0.85, 0.10, 0.15, 1.0)),
+    ("carrot",     0.011, 0.030, (0.95, 0.50, 0.10, 1.0)),
+    ("broccoli",   0.014, 0.020, (0.20, 0.55, 0.20, 1.0)),
+]
+
+
+def assemble_table_demo(
+    *,
+    with_human: bool = True,
+    with_camera: bool = True,
+    tool: str = "articutool",
+    tool_tip: str = "fork",
+    with_floor: bool = True,
+    food: list[tuple[str, float, float, tuple[float, float, float, float]]] | None = None,
+) -> tuple[mujoco.MjModel, mujoco.MjData]:
+    """Assemble the table feeding demo and return (model, data).
+
+    Args:
+        with_human, with_camera, tool, tool_tip, with_floor: forwarded to
+            ``ada_assets.assembly.build_spec``.
+        food: List of ``(label, radius, height, rgba)`` for food cylinders.
+            Defaults to one strawberry, one carrot, one broccoli.
+
+    Returns:
+        Compiled model and data, with the JACO2 at stow keyframe and food
+        items resting on the plate.
+    """
+    if food is None:
+        food = DEFAULT_FOOD
+
+    spec = build_spec(
+        with_human=with_human,
+        with_camera=with_camera,
+        tool=tool,
+        tool_tip=tool_tip,
+        with_floor=with_floor,
+    )
+
+    plate_world_pos = _add_table_and_plate(spec)
+    food_positions = _add_food_items(spec, food, plate_world_pos)
+    model, data = compile_and_init(spec, tool=tool)
+    _init_food_qpos(model, data, food, food_positions)
+    mujoco.mj_forward(model, data)
+    return model, data
+
+
+def _add_table_and_plate(spec: mujoco.MjSpec) -> np.ndarray:
+    """Attach the ada_table and plastic_plate to ``spec``.
+
+    Uses ``StablePlacer`` to compute the plate's canonical upright pose
+    on the table surface (Bw=0 sample → centered, yaw=0).
+
+    Returns:
+        ``(3,)`` world-frame position of the plate body origin (= plate center).
+    """
+    # --- Table -----------------------------------------------------------
+    table_dir = OBJECTS_DIR / "ada_table"
+    table_spec = mujoco.MjSpec.from_file(str(table_dir / "ada_table.xml"))
+    table_spec.meshdir = str(table_dir)
+
+    table_frame = spec.worldbody.add_frame(
+        pos=TABLE_POS.tolist(),
+        quat=TABLE_QUAT.tolist(),
+    )
+    spec.attach(table_spec, prefix="table/", frame=table_frame)
+
+    # --- Plate placement via StablePlacer --------------------------------
+    placer = StablePlacer(
+        table_x=TABLE_PLACEMENT_X,
+        table_y=TABLE_PLACEMENT_Y,
+        reference="table",
+    )
+    # place_cylinder returns 2 templates: -z face down (upright), +z face down (inverted).
+    # Take the upright one.
+    template = placer.place_cylinder(
+        cylinder_radius=PLATE_RADIUS,
+        cylinder_height=PLATE_HEIGHT,
+        subject="plastic_plate",
+    )[0]
+
+    # Table-surface pose in world: TABLE_POS shifted up by surface height.
+    # (Identity orientation — the table mesh's z-up axis matches world z.)
+    T_surface_world = np.eye(4)
+    T_surface_world[:3, 3] = TABLE_POS + np.array([0.0, 0.0, TABLE_SURFACE_HEIGHT])
+
+    # Canonical pose at Bw=0 (table center, yaw=0): T_surface_world @ Tw_e
+    T_plate_world = T_surface_world @ template.Tw_e
+    plate_pos = T_plate_world[:3, 3]
+    plate_quat = _mat_to_quat(T_plate_world[:3, :3])
+
+    # --- Plate body (static — no freejoint) -------------------------------
+    plate_dir = OBJECTS_DIR / "plastic_plate"
+    plate_spec = mujoco.MjSpec.from_file(str(plate_dir / "plastic_plate.xml"))
+    plate_spec.meshdir = str(plate_dir)
+    # Drop the freejoint so the plate is welded to world.
+    plate_body = plate_spec.body("plastic_plate")
+    for j in list(plate_body.joints):
+        plate_spec.delete(j)
+
+    plate_frame = spec.worldbody.add_frame(
+        pos=plate_pos.tolist(),
+        quat=plate_quat.tolist(),
+    )
+    spec.attach(plate_spec, prefix="plate/", frame=plate_frame)
+
+    # Plate-center site (top surface, z-up) — used by ForkTSR.above_plate.
+    # The plastic_plate body origin is at the cylinder center, so the top
+    # surface is at +PLATE_HEIGHT/2 in plate frame.
+    plate_center_site = spec.worldbody.add_site()
+    plate_center_site.name = "plate_center"
+    plate_center_site.pos = (plate_pos + np.array([0.0, 0.0, PLATE_HEIGHT / 2.0])).tolist()
+    plate_center_site.size = [0.005, 0, 0]
+    plate_center_site.rgba = [0.0, 1.0, 0.0, 0.4]
+
+    return plate_pos
+
+
+def _add_food_items(
+    spec: mujoco.MjSpec,
+    food: list[tuple[str, float, float, tuple[float, float, float, float]]],
+    plate_pos: np.ndarray,
+) -> list[np.ndarray]:
+    """Add one freejoint cylinder per food item, geometry only.
+
+    The bodies start at the world origin; ``_init_food_qpos`` sets their
+    qpos to rest on the plate after compile.
+
+    Returns the list of intended (x, y, z) world positions for each food.
+    """
+    # Spread food items in a small ring on the plate surface.
+    n = len(food)
+    plate_top_z = float(plate_pos[2] + PLATE_HEIGHT / 2.0)
+    ring_radius = max(PLATE_RADIUS * 0.4, 0.02)
+
+    positions = []
+    for i, (label, r, h, _rgba) in enumerate(food):
+        theta = 2.0 * np.pi * i / max(n, 1)
+        # Center the food cylinder vertically with its base on the plate top.
+        z = plate_top_z + h / 2.0 + 0.001  # tiny gap to avoid initial contact
+        positions.append(
+            np.array([
+                float(plate_pos[0] + ring_radius * np.cos(theta)),
+                float(plate_pos[1] + ring_radius * np.sin(theta)),
+                z,
+            ])
+        )
+
+    for i, (label, r, h, rgba) in enumerate(food):
+        body = spec.worldbody.add_body()
+        body.name = f"food/{label}_{i}"
+        fj = body.add_freejoint()
+        fj.name = f"food/{label}_{i}/freejoint"
+        geom = body.add_geom()
+        geom.name = f"food/{label}_{i}_geom"
+        geom.type = mujoco.mjtGeom.mjGEOM_CYLINDER
+        geom.size = [r, h / 2.0, 0.0]  # cylinder: [radius, half-height, unused]
+        geom.rgba = list(rgba)
+        geom.density = 600.0  # ~bread/fruit density
+        geom.friction = [1.0, 0.01, 0.001]  # high friction so it sits on the plate
+        geom.contype = 1
+        geom.conaffinity = 1
+
+    return positions
+
+
+def _init_food_qpos(
+    model: mujoco.MjModel,
+    data: mujoco.MjData,
+    food: list[tuple[str, float, float, tuple[float, float, float, float]]],
+    positions: list[np.ndarray],
+) -> None:
+    """Set each food item's freejoint qpos to its target position on the plate."""
+    for i, (label, _r, _h, _rgba) in enumerate(food):
+        jnt_id = mujoco.mj_name2id(
+            model, mujoco.mjtObj.mjOBJ_JOINT, f"food/{label}_{i}/freejoint",
+        )
+        if jnt_id < 0:
+            continue
+        adr = model.jnt_qposadr[jnt_id]
+        data.qpos[adr:adr + 3] = positions[i]
+        data.qpos[adr + 3:adr + 7] = [1.0, 0.0, 0.0, 0.0]  # identity quat (wxyz)
+
+
+def _mat_to_quat(R: np.ndarray) -> np.ndarray:
+    """3x3 rotation matrix → MuJoCo (wxyz) quaternion."""
+    quat = np.zeros(4)
+    mujoco.mju_mat2Quat(quat, np.asarray(R, dtype=float).flatten())
+    return quat


### PR DESCRIPTION
## Summary

Builds the simulation scene for the ADA feeding demo: ADA robot in front of an over-bed table, plate placed via the upright-cylinder placement TSR, and a few bite-sized food primitives on the plate. Also lands the `ForkTSR` generator that downstream behaviors (`move_above`, `transfer_to_mouth`) will use.

Two commits:

1. **`ForkTSR`** (b5cc92d) — TSR templates for *fork tip above plate* and *fork tip approaching mouth*. Reads `T_ee_to_fork_tip` live from the model (since articutool joints change it) and bakes `inv(T_ee_to_tip)` into `Tw_e` so the planner gets EE targets.

2. **Table demo scene** (beb422a) — new `ada_mj.scenes` subpackage. `assemble_table_demo(...)`:
   - Calls `ada_assets.build_spec` (now public after [ada_assets#5](https://github.com/personalrobotics/ada_assets/pull/5)) for the bare robot.
   - Attaches `ada_table` (added in [prl_assets#15](https://github.com/personalrobotics/prl_assets/pull/15)) at the seated-namespace pose, cart on the floor.
   - Places `plastic_plate` via `StablePlacer.place_cylinder(0.133, 0.027)[0]` instantiated at the table-surface pose. The plate body lands at `table_top + plate_height/2`; with the body-origin fix from [prl_assets#16](https://github.com/personalrobotics/prl_assets/pull/16) this leaves the plate bottom flush with the table.
   - Adds a `plate_center` site at the plate top for `ForkTSR.above_plate` to reference.
   - Spawns N freejoint food cylinders (strawberry, carrot, broccoli) on a small ring around the plate center and snaps their qpos to rest just above the plate.
   - Compiles through `ada_assets.compile_and_init` so the stow keyframe and tool freejoint init stay consistent with the bare robot.
   - `ADAConfig` gains a `scene: str = \"table\"` field; `Robot._build_model` dispatches to `assemble_table_demo` for `scene=\"table\"` or `assemble_ada` for `scene=\"none\"`.

Fixes #23.

## Dependencies

- ada_assets#5 (merged) — exposes `build_spec` / `compile_and_init`.
- prl_assets#15 (merged) — adds `ada_table`.
- prl_assets#16 (merged) — plate body origin = geometric center.

## Test plan

- [x] `from ada_mj import ADA; ADA()` builds the table scene: `nbody=36 ngeom=87`, stow keyframe applied, tool snapped to grasp.
- [x] After `mj_forward`, the plate body z (`0.7485`) is exactly `table_top (0.735) + plate_half_height (0.0135)`; visible mesh world AABB z = `[0.735, 0.762]` (plate bottom on table top).
- [x] Food cylinders settle on the plate and remain stable across 1000 physics steps.
- [x] Visually confirmed in mj_viser: table standing on the floor with five-primitive collision (top slab + 2 feet + 2 columns), plate resting cleanly on the table top, food on the plate.