### PR TITLE
move_above: plan to a ForkTSR placement TSR over the food

### DIFF
--- a/src/ada_mj/feeding/behaviors.py
+++ b/src/ada_mj/feeding/behaviors.py
@@ -66,47 +66,58 @@ def move_above(
     *,
     arm: Arm,
     ctx: ExecutionContext,
+    fork_tsr,
+    xy_slop: float = 0.008,
 ) -> Outcome:
-    """Plan and execute motion to the approach pose above a food item.
+    """Plan and execute motion to a fork-tip-above-food pose.
 
-    The approach pose is the food position offset by the schema's
-    approach_offset (typically a few cm above). Uses IK + planner if
-    an IK solver is available, otherwise plans to the target pose
-    directly.
+    Builds a placement TSR over the food using ``ForkTSR.above_plate``
+    (fork tip pointing down, x/y free within ``xy_slop`` of the food,
+    yaw free, z at the schema's hover height above the food), then
+    calls ``arm.plan_to_tsrs`` so the planner picks any collision-free
+    configuration in that region.
+
+    Args:
+        food: Target food item (world-frame position).
+        schema: Acquisition schema; ``schema.approach_offset[2]`` sets the
+            hover height above the food (in meters).
+        arm: The arm to plan with.
+        ctx: Execution context (sim or hardware).
+        fork_tsr: Fork TSR generator (``robot.fork_tsr``).
+        xy_slop: Half-width of the xy region the planner may pick the
+            fork tip within, around the food's xy (meters). Tight by
+            default so the subsequent acquisition stab actually hits the
+            food.
     """
-    target_pos = food.position + schema.approach_offset
+    hover_height = abs(float(schema.approach_offset[2]))
 
-    # Build target pose: food approach position, current EE orientation
-    target_pose = arm.get_ee_pose().copy()
-    target_pose[:3, 3] = target_pos
+    # Reference frame: food position, identity rotation (z-up world).
+    T_food_world = np.eye(4)
+    T_food_world[:3, 3] = food.position
 
-    # Try IK → plan_to_configuration (precise, works for EAIK arms)
-    q_goal = _ik_to_position(arm, target_pos)
-    if q_goal is not None:
-        path = arm.plan_to_configuration(q_goal)
-        if path is not None:
-            traj = arm.retime(path)
-            if ctx.execute(traj):
-                return success(food=food.name)
-            return failure(
-                FailureKind.EXECUTION_FAILED,
-                "move_above:execution_failed",
-                food=food.name,
-            )
+    # k=1 → single height template at exactly hover_height; the planner
+    # gets x/y slop and yaw freedom but pins the tip at the requested z.
+    templates = fork_tsr.above_plate(
+        plate_radius=xy_slop, hover_height=hover_height, k=1,
+    )
+    goal_tsrs = [t.instantiate(T_food_world) for t in templates]
 
-    # Fallback: plan_to_pose (for arms without IK, e.g., JACO2 with mink)
-    if hasattr(arm, "plan_to_pose"):
-        path = arm.plan_to_pose(target_pose)
-        if path is not None:
-            traj = arm.retime(path)
-            if ctx.execute(traj):
-                return success(food=food.name)
+    path = arm.plan_to_tsrs(goal_tsrs)
+    if path is None:
+        return failure(
+            FailureKind.PLANNING_FAILED,
+            "move_above:no_path",
+            food=food.name,
+            food_pos=food.position.tolist(),
+        )
 
+    traj = arm.retime(path)
+    if ctx.execute(traj):
+        return success(food=food.name)
     return failure(
-        FailureKind.PLANNING_FAILED,
-        "move_above:no_path",
+        FailureKind.EXECUTION_FAILED,
+        "move_above:execution_failed",
         food=food.name,
-        target_pos=target_pos.tolist(),
     )
 
 
@@ -316,27 +327,3 @@ def retract_from_mouth(
     )
 
 
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
-def _ik_to_position(arm: Arm, position: np.ndarray) -> np.ndarray | None:
-    """Solve IK for a target position, keeping current orientation.
-
-    Returns the closest joint configuration or None if unreachable.
-    """
-    target_pose = arm.get_ee_pose().copy()
-    target_pose[:3, 3] = position
-
-    if arm.ik_solver is None:
-        return None
-
-    solutions = arm.ik_solver.solve(target_pose, q_init=arm.get_joint_positions())
-    if not solutions:
-        return None
-
-    # Pick closest to current
-    q_current = arm.get_joint_positions()
-    best = min(solutions, key=lambda q: float(np.linalg.norm(np.array(q) - q_current)))
-    return np.array(best)

--- a/src/ada_mj/feeding/task.py
+++ b/src/ada_mj/feeding/task.py
@@ -68,13 +68,15 @@ def feed_bite(
     if not result:
         return result
 
-    # 2. Move above the food item
-    result = move_above(food, schema, arm=arm, ctx=ctx)
+    # 2. Tilt fork for acquisition.
+    # Done before move_above so the articutool pose is fixed when ForkTSR
+    # captures T_ee_to_fork_tip and the planner solves arm IK.
+    result = tilt_fork(schema.tilt_angle, ctx=ctx)
     if not result:
         return result
 
-    # 3. Tilt fork for acquisition
-    result = tilt_fork(schema.tilt_angle, ctx=ctx)
+    # 3. Move above the food item
+    result = move_above(food, schema, arm=arm, ctx=ctx, fork_tsr=robot.fork_tsr)
     if not result:
         return result
 

--- a/src/ada_mj/robot.py
+++ b/src/ada_mj/robot.py
@@ -128,6 +128,9 @@ class ADA:
 
             self._head = HeadController(self.model, self.data, self.config.head)
 
+        # Fork TSR generator — constructed lazily on first use via .fork_tsr
+        self._fork_tsr = None
+
         # Wrist camera (if camera present)
         self._camera = None
         if self.config.with_camera:
@@ -170,7 +173,7 @@ class ADA:
         """
         if self.config.tool is None:
             return
-        from ada_assets.assembly import TOOLS, _init_tool_pose
+        from ada_assets.assembly import _init_tool_pose
 
         _init_tool_pose(self.model, self.data, self.config.tool, self.config.tool)
 
@@ -239,6 +242,27 @@ class ADA:
     def grasp_manager(self) -> GraspManager:
         """Shared grasp manager."""
         return self._grasp_manager
+
+    @property
+    def fork_tsr(self):
+        """Fork TSR generator (lazy, cached).
+
+        Reads ``T_ee_to_fork_tip`` live from the model at each call so the
+        TSR tracks articutool joint changes. Requires a fork-bearing tool
+        (``articutool`` or ``forque``) — raises ``ValueError`` otherwise.
+        """
+        if self._fork_tsr is None:
+            if self.config.tool is None:
+                raise ValueError("fork_tsr requires a fork-bearing tool (articutool or forque)")
+            from ada_mj.feeding.fork_tsr import ForkTSR
+
+            self._fork_tsr = ForkTSR(
+                model=self.model,
+                data=self.data,
+                ee_site_name=self.config.ee_site,
+                tip_site_name=f"{self.config.tool}/fork_tip",
+            )
+        return self._fork_tsr
 
     @property
     def named_poses(self) -> dict[str, np.ndarray]:


### PR DESCRIPTION
## Summary

Replaces `move_above`'s old "IK to (food + approach_offset), plan to that joint config" path with a TSR-based plan: build a fork-tip TSR over the food and let the CBiRRT planner pick any collision-free arm configuration that satisfies it.

The articutool joints are frozen at planning time (captured into `T_ee_to_fork_tip` as a snapshot). Only the 6 arm joints are in the planning DOFs. The contract is: caller picks the tool pose via `tilt_fork(...)` first, `move_above(...)` moves the arm to land the fork tip — at that frozen tool pose — above the food, pointing down.

## Changes

- **`feeding/behaviors.py — move_above`**: build a frame at `food.position` (identity rotation), call `fork_tsr.above_plate(plate_radius=xy_slop, hover_height, k=1)` for a single TSR template, instantiate it at the food frame, plan via `arm.plan_to_tsrs`.
  - The TSR constrains the fork tip: xy within `xy_slop` (default 8 mm) of the food, z at `hover_height` (= `|schema.approach_offset[2]|`, default 25 mm above food), pointing down (z-axis = world −z), yaw free.
  - `k=1` because we want exactly one z and no upward variants — the subsequent acquisition stab depends on a known hover height.
  - The unused `_ik_to_position` helper is removed.
- **`feeding/task.py`**: swap the order of `tilt_fork(schema.tilt_angle, ...)` and `move_above(...)`. The articutool must already be at the schema's tilt pose when `ForkTSR` captures `T_ee_to_fork_tip`, or the back-computed EE goals are infeasible.
- **`robot.py`**: lazy `robot.fork_tsr` property that constructs `ForkTSR` with the current tool's `<tool>/fork_tip` site. Raises if no tool is configured.

## Verification

Kinematic sim from `JACO2_RESTING`, default `straight_skewer()` schema, `strawberry_0` at world `(0.113, −0.480, 0.774)`:

- `tare_ft` → success
- `tilt_fork(−π/4)` → success (articutool reaches −0.785 rad)
- `move_above` → success
  - fork tip: `(0.107, −0.482, 0.799)`
  - **xy error: 6.5 mm** (within 8 mm slop)
  - **z above food: 25.0 mm** (exactly the constrained value)

Visually confirmed in mj_viser: the arm tilts the fork, plans, and executes a smooth path landing the fork tip above the strawberry with the fork pointing straight down.

## Known limits (deliberate, see follow-up issues)

- **Physics-mode `tilt_fork` doesn't settle** ([#28](https://github.com/personalrobotics/ada_mj/issues/28)) — one PD step advances the articutool by ~0.002 rad. The TSR captures the wrong pre-tilt, planning fails. Kinematic mode works end-to-end; physics mode needs the tilt_fork fix from #28.
- **Per-food / per-tilt reachability is not automatic** — the planner can't compensate for a bad tilt by curling the articutool. The schema's −π/4 tilt was tuned for skewer feasibility; tilts and food positions outside that envelope can fail with `PLANNING_FAILED: no_path`. A follow-up issue tracks this.