### PR TITLE
transfer_to_mouth: TSR plan + servo + ForkTSR tool-snap fix

### DIFF
--- a/src/ada_mj/feeding/behaviors.py
+++ b/src/ada_mj/feeding/behaviors.py
@@ -242,24 +242,69 @@ def transfer_to_mouth(
     *,
     arm: Arm,
     ctx: ExecutionContext,
+    fork_tsr,
+    plan_approach_distance: float = 0.05,
+    servo_approach_distance: float = 0.02,
 ) -> Outcome:
-    """Move the loaded fork to the user's mouth.
+    """Move the loaded fork to the user's mouth in two phases.
 
-    Servos from the current pose (staging) toward the mouth position,
-    maintaining the current fork orientation. The speed profile
-    decelerates from 0.15 m/s to 0.06 m/s near the mouth.
-    F/T threshold is 1N — sensitive to detect lip/face contact.
+    Phase 1 (long-range, collision-aware): plan an arm path to a fork-tip
+    approach TSR — fork tip ``plan_approach_distance`` in front of the
+    mouth along its +x axis, pointing toward the mouth, with small
+    lateral and orientation freedom for the planner to find a feasible
+    config. Uses ``arm.plan_to_tsrs`` so the planner samples within the
+    TSR and picks any collision-free configuration.
 
-    The fork orientation is set by the staging pose (which the planner
-    achieved). The servo preserves it — we translate to the mouth,
-    we don't rotate to match the mouth frame.
+    Phase 2 (close-range, force-aware): from the planned pose, servo the
+    last few cm to ``servo_approach_distance`` from the mouth using
+    ``servo_to_pose`` with the mouth approach speed profile and a tight
+    F/T threshold (1 N) so lip / face contact aborts safely.
+
+    The articutool joints are frozen at planning time (snapshotted into
+    the TSR's ``Tw_e``); only arm joints move during phase 1, and the
+    servo in phase 2 preserves the EE orientation.
+
+    Args:
+        mouth_pose: 4×4 world-frame pose of the mouth (+x out of face).
+        arm: The arm to plan / servo with.
+        ctx: Execution context (sim or hardware).
+        fork_tsr: Fork TSR generator (``robot.fork_tsr``).
+        plan_approach_distance: How far in front of the mouth the planner
+            should target the fork tip (meters). Default 5 cm.
+        servo_approach_distance: Final standoff distance after the servo
+            (meters). Default 2 cm.
     """
-    # Target: mouth position, current fork orientation.
-    # The mouth frame orientation is the face's forward direction —
-    # not related to how the fork should be oriented.
-    approach_distance = 0.02  # stop 2cm from mouth
-    target = arm.get_ee_pose().copy()  # keep current orientation
-    target[:3, 3] = mouth_pose[:3, 3] + mouth_pose[:3, 0] * approach_distance
+    # Phase 1: plan into the approach TSR
+    templates = fork_tsr.approach_mouth(
+        approach_distance=plan_approach_distance, k=3,
+    )
+    goal_tsrs = [t.instantiate(mouth_pose) for t in templates]
+
+    path = arm.plan_to_tsrs(goal_tsrs)
+    if path is None:
+        return failure(
+            FailureKind.PLANNING_FAILED,
+            "transfer_to_mouth:no_path",
+            mouth_pos=mouth_pose[:3, 3].tolist(),
+        )
+    traj = arm.retime(path)
+    if not ctx.execute(traj):
+        return failure(
+            FailureKind.EXECUTION_FAILED,
+            "transfer_to_mouth:plan_execute_failed",
+        )
+
+    # Phase 2: servo the last few cm with F/T monitoring.
+    # The TSR plan landed the fork tip ~plan_approach_distance from the
+    # mouth. We want the fork tip at servo_approach_distance from the
+    # mouth, preserving the EE orientation that the plan achieved. Since
+    # the articutool joints are frozen during the servo, translating the
+    # EE by the desired fork-tip delta translates the fork tip by the
+    # same amount.
+    tip_now = fork_tsr.tip_world_pos()
+    tip_target = mouth_pose[:3, 3] + mouth_pose[:3, 0] * servo_approach_distance
+    target = arm.get_ee_pose().copy()
+    target[:3, 3] = target[:3, 3] + (tip_target - tip_now)
 
     return servo_to_pose(
         target,
@@ -268,7 +313,7 @@ def transfer_to_mouth(
         speed_profile=MOUTH_APPROACH_SPEED,
         ft_threshold=MOUTH_FT_THRESHOLD,
         position_tol=MOUTH_POSITION_TOL,
-        timeout=15.0,
+        timeout=10.0,
     )
 
 

--- a/src/ada_mj/feeding/fork_tsr.py
+++ b/src/ada_mj/feeding/fork_tsr.py
@@ -51,18 +51,52 @@ class ForkTSR:
         self._data = data
         self._ee_site_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_SITE, ee_site_name)
         self._tip_site_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_SITE, tip_site_name)
+        # Tool prefix derived from the tip site name (e.g. "articutool/fork_tip"
+        # → "articutool"). Used to re-snap the welded tool freejoint when the
+        # caller has changed arm joints without running the controller.
+        self._tool = tip_site_name.split("/")[0] if "/" in tip_site_name else None
 
         if self._ee_site_id < 0:
             raise ValueError(f"EE site '{ee_site_name}' not found")
         if self._tip_site_id < 0:
             raise ValueError(f"Fork tip site '{tip_site_name}' not found")
 
+    def _snap_and_forward(self) -> None:
+        """Snap the welded tool freejoint to the current arm pose, then
+        run forward kinematics so site positions reflect the snap.
+
+        Without this, callers that change arm joints directly (e.g.
+        ``arm.set_joint_positions`` between sim contexts) leave the tool
+        freejoint at its old world position. The fork tip site we read
+        would then describe a stale weld, and any TSR built from that
+        would target the wrong EE pose.
+        """
+        import mujoco as mj
+
+        if self._tool is not None:
+            from ada_assets.assembly import _init_tool_pose
+
+            _init_tool_pose(self._model, self._data, self._tool, self._tool)
+        mj.mj_forward(self._model, self._data)
+
+    def tip_world_pos(self) -> np.ndarray:
+        """Current fork tip position in world frame.
+
+        Snaps the tool freejoint to its weld attachment, runs forward
+        kinematics, and returns the resulting fork-tip site position.
+        """
+        self._snap_and_forward()
+        return self._data.site_xpos[self._tip_site_id].copy()
+
     def _get_T_ee_to_tip(self) -> np.ndarray:
         """Compute the current EE-to-fork-tip transform from the model.
 
-        Must be called after mj_forward so site poses are up to date.
+        Snaps the tool freejoint to its weld first, runs forward
+        kinematics, and reads site poses — so the captured transform
+        reflects the actual welded geometry.
         The transform changes with articutool joint angles.
         """
+        self._snap_and_forward()
         T_world_ee = self._site_pose(self._ee_site_id)
         T_world_tip = self._site_pose(self._tip_site_id)
         return np.linalg.inv(T_world_ee) @ T_world_tip
@@ -103,9 +137,6 @@ class ForkTSR:
         Returns:
             List of TSRTemplates. Instantiate with the plate's world pose.
         """
-        import mujoco
-
-        mujoco.mj_forward(self._model, self._data)
         T_ee_tip = self._get_T_ee_to_tip()
 
         # TSR frame: at plate surface, z-up.
@@ -192,9 +223,6 @@ class ForkTSR:
         Returns:
             List of TSRTemplates. Instantiate with the mouth's world pose.
         """
-        import mujoco
-
-        mujoco.mj_forward(self._model, self._data)
         T_ee_tip = self._get_T_ee_to_tip()
         T_tip_ee = np.linalg.inv(T_ee_tip)
 

--- a/src/ada_mj/feeding/task.py
+++ b/src/ada_mj/feeding/task.py
@@ -104,7 +104,7 @@ def feed_bite(
         )
 
     # 8. Move to mouth
-    result = transfer_to_mouth(mouth_pose, arm=arm, ctx=ctx)
+    result = transfer_to_mouth(mouth_pose, arm=arm, ctx=ctx, fork_tsr=robot.fork_tsr)
     if not result:
         return result
 


### PR DESCRIPTION
## Summary

Two-phase mouth approach:

1. **Phase 1 (collision-aware)**: build the `approach_mouth` TSR (fork tip pointing toward the mouth, a few cm in front of it, small lateral/orientation freedom) and call `arm.plan_to_tsrs` so the planner picks any collision-free configuration in that region.
2. **Phase 2 (force-aware)**: from the planned pose, servo the last few cm to a tight standoff using `servo_to_pose` with the mouth approach speed profile and a 1 N F/T threshold so lip/face contact aborts.

The servo translates the EE so the **rigid fork tip** lands the desired standoff from the mouth (not the EE itself) — respecting the EE orientation chosen by the planner.

## Latent bug fix: ForkTSR was reading a stale fork-tip site

While verifying `transfer_to_mouth` I tracked down why some `move_above` runs returned config-shaped paths that didn't actually land the fork tip at the food: `ForkTSR._get_T_ee_to_tip()` was reading the `articutool/fork_tip` site after `mj_forward` without first snapping the welded tool's freejoint. Callers that change arm joints outside the controller (e.g. `arm.set_joint_positions` before entering `robot.sim()`) leave the tool's freejoint at its old world position; the site lookup then describes a stale weld geometry and the planner solves IK to the wrong EE pose.

`ForkTSR` now calls `_init_tool_pose` + `mj_forward` before reading sites, so the captured `T_ee_to_fork_tip` always reflects the actual welded chain. `move_above` benefits from this too.

## Verification

- From `JACO2_STAGING` + articutool tilt `+π/2`, **phase 1 lands the fork tip 4 mm from the requested 15 cm staging distance.**
- Visually inspected in `mj_viser`: the arm tilts the fork, plans into the approach TSR, and executes a smooth path landing in front of the mouth.

## Known limit (tracked as follow-up)

The close-range servo (phase 2) currently trips the head's collision envelope when the fork goes inside ~10 cm of the mouth. This is a scene-collision issue (the head's body geom extends out where the fork needs to approach), not a behavior bug — ada_feeding historically handled it with selective fork↔head collision excludes. Filing as a separate issue.

The broader "TSR reachability depends on pre-tilt" pattern (issue #30) is also still in play here; the mouth approach is just as sensitive to the articutool's tilt as `move_above` is.