### PR TITLE
Demos: feeding demo + loader + CLI / console wiring (geodude pattern)

### DIFF
--- a/src/ada_mj/cli.py
+++ b/src/ada_mj/cli.py
@@ -5,10 +5,12 @@
 
 Usage::
 
-    uv run python -m ada_mj --viser                  # browser viewer (default)
-    uv run python -m ada_mj --viser --physics         # with physics
-    uv run python -m ada_mj --tool forque --viser     # forque instead of articutool
-    uv run python -m ada_mj --tool-tip spoon --viser  # spoon tip
+    uv run python -m ada_mj --viser                       # bare table scene
+    uv run python -m ada_mj --demo feeding --viser        # feeding demo
+    uv run python -m ada_mj --list-demos                  # list demos and exit
+    uv run python -m ada_mj --viser --physics             # with physics
+    uv run python -m ada_mj --tool forque --viser         # forque tool
+    uv run python -m ada_mj --tool-tip spoon --viser      # spoon tip
 """
 
 from __future__ import annotations
@@ -22,6 +24,8 @@ def main() -> None:
         prog="ada",
         description="ADA interactive console",
     )
+    parser.add_argument("--demo", type=str, default=None, help="Demo name (see --list-demos) or path to a demo file.")
+    parser.add_argument("--list-demos", action="store_true", help="List available demos and exit.")
     parser.add_argument("--tool", choices=["articutool", "forque"], default="articutool",
                         help="Tool to attach (default: articutool).")
     parser.add_argument("--tool-tip", choices=["fork", "spoon"], default="fork",
@@ -36,20 +40,39 @@ def main() -> None:
                         help="Launch browser viewer at http://localhost:8080.")
     args = parser.parse_args()
 
+    if args.list_demos:
+        from ada_mj.demo_loader import list_demos
+
+        list_demos()
+        sys.exit(0)
+
     from ada_mj.config import ADAConfig
 
+    demo_module = None
+    if args.demo is not None:
+        from ada_mj.demo_loader import load_demo
+
+        demo_module = load_demo(args.demo)
+
     tool = None if args.no_tool else args.tool
+    scene = demo_module.scene["name"] if demo_module is not None else ADAConfig().scene
     config = ADAConfig(
         tool=tool,
         tool_tip=args.tool_tip,
         with_human=not args.no_human,
         with_camera=not args.no_camera,
+        scene=scene,
     )
 
     from ada_mj.robot import ADA
 
-    print(f"\nLoading ADA (tool={tool}, tip={args.tool_tip})...", flush=True)
+    print(f"\nLoading ADA (tool={tool}, tip={args.tool_tip}, scene={scene})...", flush=True)
     robot = ADA(config)
+
+    if demo_module is not None:
+        from ada_mj.demo_loader import apply_initial_pose
+
+        apply_initial_pose(demo_module, robot)
 
     from ada_mj.console import start_console
 
@@ -58,4 +81,5 @@ def main() -> None:
         physics=args.physics,
         viewer=args.viewer,
         viser=args.viser,
+        demo_module=demo_module,
     )

--- a/src/ada_mj/console.py
+++ b/src/ada_mj/console.py
@@ -10,6 +10,7 @@ ADA-specific panels and namespace entries.
 from __future__ import annotations
 
 import logging
+from types import ModuleType
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -24,6 +25,7 @@ def start_console(
     physics: bool = False,
     viewer: bool = False,
     viser: bool = False,
+    demo_module: ModuleType | None = None,
 ) -> None:
     """Launch the ADA IPython console.
 
@@ -32,6 +34,9 @@ def start_console(
         physics: Enable physics simulation.
         viewer: Launch native MuJoCo viewer (requires mjpython).
         viser: Launch browser viewer at http://localhost:8080.
+        demo_module: Loaded demo module — its public functions are added
+            to the IPython namespace and ``robot`` is injected as a
+            module-level global on the demo for use by those functions.
     """
     from mj_manipulator.console import start_console as _start_console
 
@@ -90,6 +95,14 @@ IPython:
         "commands": commands,
         "go_to": lambda pose_name: robot.go_to(pose_name),
     }
+
+    # Wire in demo functions if a demo was loaded — same pattern as geodude.
+    if demo_module is not None:
+        from ada_mj.demo_loader import get_demo_functions, inject_robot
+
+        inject_robot(demo_module, robot)
+        for fn_name, fn in get_demo_functions(demo_module).items():
+            extra_ns[fn_name] = fn
 
     # -- Panel setup callback (same pattern as geodude) -------------------------
     def _setup_ada_panels(gui, viewer, robot, event_loop, tabs):

--- a/src/ada_mj/demo_loader.py
+++ b/src/ada_mj/demo_loader.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Demo discovery and loading for ADA.
+
+Demos are Python files with a ``scene`` dict (currently just ``{"name": ...}``,
+picking which ADA scene to build) and a handful of public helper functions.
+They live in :mod:`ada_mj.demos` or any user-provided file.
+
+Example demo file::
+
+    \"\"\"My demo — describe in one line.\"\"\"
+    scene = {"name": "table"}
+
+    def hello():
+        print(robot)
+
+The console injects ``robot`` (and, while inside ``robot.sim()``, the active
+context is reachable via ``robot._active_context``) into the loaded demo
+module and re-exports the demo's public functions into the IPython namespace.
+
+This mirrors the same pattern used in :mod:`geodude.demo_loader`. Scene
+resolution differs: ada_mj scenes are deterministic (built by
+:mod:`ada_mj.scenes`), so there is no object-spawning step.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import inspect
+import logging
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ada_mj.robot import ADA
+
+logger = logging.getLogger(__name__)
+
+DEMOS_DIR = Path(__file__).parent / "demos"
+
+
+def discover_demos() -> dict[str, Path]:
+    """Find all demos in the demos/ directory. Returns ``{name: path}``."""
+    demos: dict[str, Path] = {}
+    if not DEMOS_DIR.is_dir():
+        return demos
+    for p in sorted(DEMOS_DIR.glob("*.py")):
+        if p.name.startswith("_"):
+            continue
+        demos[p.stem] = p
+    return demos
+
+
+def _get_demo_description(path: Path) -> str:
+    """Extract the first line of a demo file's docstring without importing."""
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith('"""') or line.startswith("'''"):
+                quote = line[:3]
+                content = line[3:]
+                if content.endswith(quote):
+                    return content[:-3].strip()
+                return content.strip()
+            if line and not line.startswith("#"):
+                break
+    return path.stem
+
+
+def list_demos() -> None:
+    """Print available demos with their one-line descriptions."""
+    found = discover_demos()
+    if not found:
+        print("No demos found.")
+        return
+    print("\nAvailable demos:\n")
+    for name, path in found.items():
+        print(f"  {name:20s} — {_get_demo_description(path)}")
+    print()
+
+
+def load_demo(name_or_path: str) -> ModuleType:
+    """Load a demo by name (from ``demos/``) or file path."""
+    path = Path(name_or_path)
+    if path.is_file():
+        spec = importlib.util.spec_from_file_location(path.stem, path)
+        if spec is None or spec.loader is None:
+            raise ValueError(f"Could not load demo from '{path}'")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    demos = discover_demos()
+    if name_or_path in demos:
+        return load_demo(str(demos[name_or_path]))
+
+    raise ValueError(
+        f"Demo '{name_or_path}' not found. "
+        f"Available: {', '.join(demos.keys()) or 'none'}"
+    )
+
+
+def inject_robot(demo_module: ModuleType, robot: ADA) -> None:
+    """Set ``robot`` as a module-level global on ``demo_module``."""
+    demo_module.robot = robot
+
+
+def apply_initial_pose(demo_module: ModuleType, robot: ADA) -> None:
+    """If the demo declares ``scene["initial_pose"]``, move the arm there.
+
+    Demos use this when the default ``stow`` keyframe collides with
+    something the demo's scene adds (e.g. the feeding demo's plate
+    overlaps the fork at stow). Set ``initial_pose`` in the demo's
+    ``scene`` dict to one of ``robot.named_poses``.
+    """
+    pose_name = getattr(demo_module, "scene", {}).get("initial_pose")
+    if pose_name is None:
+        return
+    if pose_name not in robot.named_poses:
+        raise ValueError(
+            f"Demo declares initial_pose='{pose_name}', "
+            f"but robot has no such named pose. Available: "
+            f"{sorted(robot.named_poses)}"
+        )
+    robot.arm.set_joint_positions(robot.named_poses[pose_name])
+    # Snap the welded tool freejoint to the new link_6 pose and re-run FK so
+    # the visible state matches the new joint config before the console
+    # starts.
+    robot._snap_tool_to_weld()
+    import mujoco
+
+    mujoco.mj_forward(robot.model, robot.data)
+    # Reset ctrl so position actuators don't fight the new qpos when physics
+    # starts later.
+    robot._init_ctrl_from_qpos()
+
+
+def get_demo_functions(demo_module: ModuleType) -> dict[str, Callable]:
+    """Return the public functions defined in ``demo_module``.
+
+    Skips any function whose name starts with ``_`` or that was imported from
+    elsewhere.
+    """
+    return {
+        name: obj
+        for name, obj in inspect.getmembers(demo_module, inspect.isfunction)
+        if not name.startswith("_") and obj.__module__ == demo_module.__name__
+    }

--- a/src/ada_mj/demos/__init__.py
+++ b/src/ada_mj/demos/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""ADA demos — interactive tasks for the console.
+
+Each demo file declares the scene it expects (e.g. ``"table"``) and a
+handful of public helper functions that operate on the ``robot`` global
+injected by the demo loader. See :mod:`ada_mj.demo_loader`.
+"""

--- a/src/ada_mj/demos/feeding.py
+++ b/src/ada_mj/demos/feeding.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Feeding demo — acquire food from the plate and deliver it to the mouth.
+
+Helpers available in the console after launching with ``--demo feeding``:
+
+  food_items()              — list of FoodItem instances for the food bodies
+                              currently in the scene
+  feed(food=None)           — run one feed_bite cycle for ``food`` (defaults
+                              to the first food on the plate)
+  feed_all()                — run feed_bite for each food item in order
+  move_above_food(food=None)— just the pre-acquisition phase (TSR-plan the
+                              fork tip above a food item, schema-tilted)
+  transfer(plan=0.15, servo=0.10)
+                            — just the mouth-transfer phase (TSR-plan to a
+                              staging distance, then servo to a standoff)
+
+The demo expects the ``table`` scene (ADAConfig.scene = "table"), which the
+loader sets automatically when ``--demo feeding`` is passed on the CLI.
+"""
+
+from __future__ import annotations
+
+scene = {
+    "name": "table",
+    # Start at "above_plate" — the wrist camera looks down at the plate
+    # from here, which is the natural starting view for a feeding session.
+    # (The default "stow" keyframe parks the fork inside the plate, so we
+    # need a different starting pose anyway.)
+    "initial_pose": "above_plate",
+}
+
+
+def food_items():
+    """Return a list of :class:`FoodItem` for every ``food/*`` body in the scene.
+
+    Reads positions from the live MuJoCo state, so the list always reflects
+    the current state of the plate.
+    """
+    import mujoco
+
+    from ada_mj.feeding.domain import FoodItem
+
+    items = []
+    for bid in range(robot.model.nbody):
+        name = mujoco.mj_id2name(robot.model, mujoco.mjtObj.mjOBJ_BODY, bid) or ""
+        if not name.startswith("food/"):
+            continue
+        pos = robot.data.xpos[bid].copy()
+        # name format: "food/<label>_<idx>" — strip trailing _idx for food_type
+        label = name.split("/", 1)[1]
+        food_type = label.rsplit("_", 1)[0] if "_" in label else label
+        items.append(FoodItem(name=name, position=pos, food_type=food_type))
+    return items
+
+
+def feed(food=None, schema=None):
+    """Run one ``feed_bite`` cycle.
+
+    Args:
+        food: A :class:`FoodItem`. Defaults to the first item from
+            :func:`food_items`.
+        schema: Acquisition schema. Defaults to ``straight_skewer()``.
+    """
+    from ada_mj.feeding.task import feed_bite
+
+    if food is None:
+        items = food_items()
+        if not items:
+            print("No food items found.")
+            return None
+        food = items[0]
+    return feed_bite(food, schema, robot=robot, ctx=robot._active_context)
+
+
+def feed_all():
+    """Run ``feed_bite`` for each food item in order."""
+    from ada_mj.feeding.task import feeding_demo
+
+    return feeding_demo(food_items(), robot=robot, ctx=robot._active_context)
+
+
+def move_above_food(food=None):
+    """Just the pre-acquisition phase: tilt the fork, then TSR-plan above food.
+
+    Useful for visualizing what ``move_above`` does without running the whole
+    bite cycle.
+    """
+    from ada_mj.feeding.behaviors import move_above, tilt_fork
+    from ada_mj.feeding.domain import straight_skewer
+
+    if food is None:
+        items = food_items()
+        if not items:
+            print("No food items found.")
+            return None
+        food = items[0]
+    schema = straight_skewer()
+    res = tilt_fork(schema.tilt_angle, ctx=robot._active_context)
+    if not res:
+        return res
+    return move_above(
+        food, schema, arm=robot.arm, ctx=robot._active_context, fork_tsr=robot.fork_tsr,
+    )
+
+
+def transfer(plan: float = 0.15, servo: float = 0.10):
+    """Just the mouth-transfer phase: TSR-plan to ``plan`` m, servo to ``servo`` m.
+
+    Useful for visualizing what ``transfer_to_mouth`` does without running
+    the whole bite cycle. Defaults are conservative (15 cm staging,
+    10 cm servo standoff) to stay clear of the head collision envelope.
+    """
+    from ada_mj.feeding.behaviors import transfer_to_mouth
+
+    mouth_pose = robot.head.get_mouth_pose()
+    return transfer_to_mouth(
+        mouth_pose, arm=robot.arm, ctx=robot._active_context, fork_tsr=robot.fork_tsr,
+        plan_approach_distance=plan, servo_approach_distance=servo,
+    )


### PR DESCRIPTION
## Summary

Mirror the `geodude` demos pattern in `ada_mj`: each demo is a single Python file declaring the scene it expects and a small set of public helper functions. The console picks up the demo's functions automatically.

```
uv run python -m ada_mj --demo feeding --viser     # browser viewer + IPython
uv run python -m ada_mj --list-demos               # list discovered demos
```

## What's wired

- **`ada_mj/demos/feeding.py`** — first demo. Declares `scene = {"name": "table", "initial_pose": "above_plate"}` and exposes:
  - `food_items()` — list of `FoodItem` for every `food/*` body in the scene
  - `feed(food=None)` — one `feed_bite` cycle (defaults to the first food on the plate)
  - `feed_all()` — `feeding_demo` across every food item
  - `move_above_food(food=None)` — just the pre-acquisition TSR plan, useful for visualizing
  - `transfer(plan=0.15, servo=0.10)` — just the mouth-transfer TSR plan + servo
- **`ada_mj/demo_loader.py`** — `discover_demos`, `list_demos`, `load_demo`, `inject_robot`, `apply_initial_pose`, `get_demo_functions`. Matches the API surface of `geodude.demo_loader`.
- **CLI**: `--demo NAME` loads the demo, picks up `scene["name"]` to set `ADAConfig.scene`, and calls `apply_initial_pose` to drive the arm to the demo's declared starting pose before the console comes up. `--list-demos` prints discovered demos and exits.
- **Console**: when a demo is loaded, `inject_robot` stamps the demo module's `robot` global and the demo's public functions are added to the IPython namespace so they're typeable without imports.

## Initial-pose handling

The default `stow` keyframe parks the JACO 2 fork tine inside the table demo's plate (we measured 7.6 mm penetration), so the feeding demo declares `initial_pose: "above_plate"` — same height as stow, but the wrist camera is naturally pointed at the plate, which is the right starting view for a feeding session anyway. `apply_initial_pose` writes the arm joints, snaps the welded tool to the new link_6 pose, runs `mj_forward`, and resets `data.ctrl` so physics doesn't fight the new pose. After this `robot.arm.check_collisions()` reports clean.

A follow-up should tune `JACO2_STOW` in `ada_assets` so it stays clear of the plate too — tracked separately.

## End-to-end status

The demo's design is right. End-to-end reliability (e.g. `feed()` completing a full bite cycle) is currently bottlenecked on JACO 2 IK falling back to `mink` (EAIK has no analytical decomposition for non-Pieper 6R; tracked as mj_manipulator#158 for the `ssik` integration). When `ssik` lands the demo doesn't change — it just becomes deterministic instead of tilt-sensitive.

`move_above_food()` and `transfer(plan=0.20, servo=0.15)` work today on most articutool tilts, which is enough to walk through the geometry visually.

## Test plan

- [x] `uv run python -m ada_mj --list-demos` prints `feeding`.
- [x] `uv run python -m ada_mj --demo feeding --viser` builds the table scene, parks at `above_plate`, opens the viser browser viewer, and IPython exposes `food_items`, `feed`, `feed_all`, `move_above_food`, `transfer`.
- [x] `robot.arm.check_collisions()` reports clean at startup.
- [x] `food_items()` returns three items (strawberry, carrot, broccoli) with world positions matching the table scene's freejoint qpos.