### PR TITLE
jaco2: wire ssik analytical IK (replaces mink fallback)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,11 @@ license = "MIT"
 authors = [
     {name = "Siddhartha Srinivasa", email = "siddhartha.srinivasa@gmail.com"},
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"  # ssik (transitive via JACO 2 IK) requires 3.11+
 dependencies = [
     "numpy",
     "mujoco",
+    "ssik>=1.1.0",
     "ada-assets @ git+https://github.com/personalrobotics/ada_assets.git",
     "mj-manipulator @ git+https://github.com/personalrobotics/mj_manipulator.git",
     "mj-environment @ git+https://github.com/personalrobotics/mj_environment.git",

--- a/src/ada_mj/jaco2.py
+++ b/src/ada_mj/jaco2.py
@@ -6,8 +6,10 @@
 The j2n6s200 is a 6-DOF arm with a **non-spherical** wrist (the "n"
 in the model name). Joints 4-6 have 37-73 mm offsets between their
 axes, which means EAIK has no analytical decomposition. The factory
-uses ``resolve_ik_solver(with_ik="auto")`` which falls back to mink
-numerical IK automatically.
+passes ssik's ``jaco2_ik`` prebuilt to ``resolve_ik_solver`` so the
+``"auto"`` chain skips EAIK (which refuses) and lands on ssik
+(analytical, every branch). mink remains the final fallback if
+ssik fails to construct for any reason.
 
 All joint specs from ``ada_ros2/ada_description/urdf/j2n6s200.xacro``.
 Named configurations from ``ada_feeding/config/ada_feeding_action_servers_default.yaml``.
@@ -21,7 +23,6 @@ import numpy as np
 
 if TYPE_CHECKING:
     from mj_environment import Environment
-
     from mj_manipulator.arm import Arm
 
 # ---------------------------------------------------------------------------
@@ -95,12 +96,23 @@ def create_jaco2_arm(
     extra_arm_body_names: list[str] | None = None,
     grasp_manager=None,
 ) -> "Arm":
-    """Create a JACO2 arm with mink IK (EAIK has no decomposition for this arm).
+    """Create a JACO2 arm with analytical IK via ssik.
+
+    EAIK refuses the JACO2's non-Pieper 6R geometry, so the factory's
+    ``"auto"`` chain skips EAIK and uses ssik's ``jaco2_ik`` prebuilt.
+    ssik returns every analytical branch (typically 2-8 per pose) with
+    sub-micron FK closure — a substantial upgrade over mink's seeded
+    single-solution numerical IK, particularly for ``arm.plan_to_tsrs``
+    where the planner samples many EE goals from a TSR.
 
     Args:
         env: MuJoCo environment containing the ADA model.
-        ee_site: Name of the end-effector site.
-        with_ik: IK solver mode (default "auto" → mink fallback).
+        ee_site: Name of the end-effector site on the arm chain (not on
+            the welded tool — ssik solves for the arm only).
+        with_ik: IK solver mode. ``"auto"`` (default) tries EAIK first
+            (it'll refuse for JACO2), then ssik, then mink. ``"ssik"``
+            forces ssik directly. ``"mink"`` falls back to the previous
+            numerical solver.
         extra_arm_body_names: Bodies to treat as part of the arm for
             collision checking (e.g., welded tool root body).
 
@@ -110,6 +122,11 @@ def create_jaco2_arm(
     from mj_manipulator.arm import Arm
     from mj_manipulator.arms._ik_factory import resolve_ik_solver
     from mj_manipulator.config import ArmConfig, KinematicLimits, PlanningDefaults
+
+    # ssik's jaco2_ik prebuilt — covers the nominal manufacturer geometry,
+    # which matches ada_assets' JACO2 model. The welded articutool sits
+    # past the EE site so it doesn't enter the arm IK chain.
+    from ssik.prebuilt import jaco2_ik
 
     config = ArmConfig(
         name="jaco2",
@@ -122,10 +139,10 @@ def create_jaco2_arm(
         ee_site=ee_site,
         extra_arm_body_names=extra_arm_body_names,
         planning_defaults=PlanningDefaults(smoothing_iterations=25),
-        max_cartesian_speed=0.06,   # near humans, conservative
+        max_cartesian_speed=0.06,  # near humans, conservative
         max_cartesian_angular=0.3,
     )
 
     arm = Arm(env, config)
-    ik_solver = resolve_ik_solver(arm, with_ik=with_ik)
+    ik_solver = resolve_ik_solver(arm, with_ik=with_ik, ssik_module=jaco2_ik)
     return Arm(env, config, ik_solver=ik_solver, grasp_manager=grasp_manager)


### PR DESCRIPTION
## Summary

`mj_manipulator`'s factory now dispatches EAIK → ssik → mink (personalrobotics/mj_manipulator#159, merged). Pass the JACO 2 prebuilt artifact (`ssik.prebuilt.jaco2_ik`) to `resolve_ik_solver` so ADA's JACO 2 picks up ssik instead of falling all the way through to mink.

EAIK still refuses (non-Pieper 6R), but ssik covers exactly that gap with analytical IK and full branch enumeration. Sub-micron FK closure, deterministic — vs mink's seeded numerical convergence that was the root cause of the tilt-sensitive reachability we saw on `arm.plan_to_tsrs`.

## End-to-end effect on the feeding demo

Before (mink): IK success rates on TSR samples were tilt-dependent and inconsistent — 0/100 at one tilt, 4/10 at another, 19/20 at a third. `arm.plan_to_tsrs` failed outright for the wrong start/tilt pair.

After (ssik, run from the `feeding` demo's `above_plate` initial pose):

```
food/strawberry_0: ok  xy_err=4.2mm  z_above=25.0mm
food/carrot_1:     ok  xy_err=4.6mm  z_above=25.0mm
food/broccoli_2:   ok  xy_err=8.5mm  z_above=25.0mm
```

Every food on the plate is reachable, deterministically.

## Changes

- `src/ada_mj/jaco2.py`: pass `ssik_module=ssik.prebuilt.jaco2_ik` into `resolve_ik_solver`. Update module + factory docstrings (the old prose claimed JACO 2 used mink — no longer true).
- `pyproject.toml`: add `ssik>=1.1.0`; bump `requires-python` to `>=3.11` (ssik wheels require it; 3.10 EOL is 2026-10).

## Out of scope (follow-ups)

- **`level_fork` is still a TODO stub** that sets articutool tilt = 0 — geometrically infeasible for mouth approach, so `feed()`'s `transfer_to_mouth` step still fails. Not caused by ssik; tracked alongside the existing reachability follow-up #30. Will file a dedicated issue for `level_fork` if we don't fold it into #30.
- **Head/fork collision excludes** for the close-range mouth servo — separate scene-tuning concern.
- **JACO2_STOW** parks the fork inside the table demo's plate — feeding demo works around it with `initial_pose: "above_plate"`. Eventually we should retune the keyframe in `ada_assets`.

## Verification

- [x] `from ada_mj import ADA; ADA()` reports `IK solver: MuJoCoSSIKSolver` (and the runtime log shows the factory's clean INFO-level dispatch message instead of the previous WARNING noise after mj_manipulator#161).
- [x] Feeding demo's `move_above_food()` succeeds for every food item with deterministic geometry.
- [x] No regressions to existing arm tests in `mj_manipulator` (475 passing on its main).