### PR TITLE
deps: declare viser + mj-viser as direct dependencies (#37)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "numpy",
     "mujoco",
     "ssik>=1.1.0",
+    "ipython>=8.0",
     "ada-assets @ git+https://github.com/personalrobotics/ada_assets.git",
     "mj-manipulator @ git+https://github.com/personalrobotics/mj_manipulator.git",
     "mj-environment @ git+https://github.com/personalrobotics/mj_environment.git",
@@ -37,9 +38,6 @@ tsr = { workspace = true }
 dev = [
     "pytest",
     "ruff",
-]
-console = [
-    "ipython>=8.0",
 ]
 
 [tool.hatch.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,17 @@ dependencies = [
     "ada-assets @ git+https://github.com/personalrobotics/ada_assets.git",
     "mj-manipulator @ git+https://github.com/personalrobotics/mj_manipulator.git",
     "mj-environment @ git+https://github.com/personalrobotics/mj_environment.git",
+    "mj-viser @ git+https://github.com/personalrobotics/mj_viser.git",
     "prl-assets @ git+https://github.com/personalrobotics/prl_assets.git",
     "tsr @ git+https://github.com/personalrobotics/tsr.git",
+    "viser>=1.0",
 ]
 
 [tool.uv.sources]
 ada-assets = { workspace = true }
 mj-manipulator = { workspace = true }
 mj-environment = { workspace = true }
+mj-viser = { workspace = true }
 prl-assets = { workspace = true }
 tsr = { workspace = true }
 


### PR DESCRIPTION
## Summary
Two related fixes to make `python -m ada_mj --viser` work on a fresh clone:

1. **viser + mj-viser** — `console.py` directly imports them (lines 111, 125) when the `--viser` panel callback runs.
2. **ipython promoted** — `mj_manipulator.console.start_console` (which ada_mj wraps) unconditionally imports IPython at runtime. ipython was declared only as an optional `[console]` extra; promoting to main deps matches the geodude pattern.

Also registers `mj-viser = { workspace = true }` so local dev resolves to the editable workspace member.

Fixes #37
Companion to [personalrobotics/mj_manipulator#163](https://github.com/personalrobotics/mj_manipulator/pull/163) and [personalrobotics/geodude#195](https://github.com/personalrobotics/geodude/pull/195).

## Test plan
- [x] `rm -rf .venv && uv sync --package ada-mj` installs all required deps.
- [x] `uv run python -m ada_mj --demo feeding --viser` launches cleanly: viser bound :8080, banner prints, REPL active.