### PR TITLE
feed_bite: log per-step entry + step-level failure (#39)

### DIFF
--- a/src/ada_mj/feeding/task.py
+++ b/src/ada_mj/feeding/task.py
@@ -63,58 +63,74 @@ def feed_bite(
 
     arm = robot.arm
 
-    # 1. Tare F/T sensor (baseline for contact detection)
+    def _failed(step: str, result: Outcome) -> Outcome:
+        # The underlying ``failure_code`` (e.g. "ft_guarded_move:no_progress")
+        # only names the *behavior*; three pipeline steps call the same
+        # behavior, so the step name has to come from here.
+        logger.warning(
+            "feed_bite[%s]: %s failed (%s)",
+            food.name, step, result.failure_code or result.failure_kind,
+        )
+        return result
+
+    logger.info("feed_bite[%s]: tare_ft", food.name)
     result = tare_ft(arm)
     if not result:
-        return result
+        return _failed("tare_ft", result)
 
-    # 2. Tilt fork for acquisition.
-    # Done before move_above so the articutool pose is fixed when ForkTSR
+    # Tilt before move_above so the articutool pose is fixed when ForkTSR
     # captures T_ee_to_fork_tip and the planner solves arm IK.
+    logger.info("feed_bite[%s]: tilt_fork (%.1f deg)", food.name, schema.tilt_angle)
     result = tilt_fork(schema.tilt_angle, ctx=ctx)
     if not result:
-        return result
+        return _failed("tilt_fork", result)
 
-    # 3. Move above the food item
+    logger.info("feed_bite[%s]: move_above", food.name)
     result = move_above(food, schema, arm=arm, ctx=ctx, fork_tsr=robot.fork_tsr)
     if not result:
-        return result
+        return _failed("move_above", result)
 
-    # 4. Stab into food
+    logger.info("feed_bite[%s]: acquire_food", food.name)
     result = acquire_food(food, schema, arm=arm, ctx=ctx)
     if result.failure_kind == FailureKind.SAFETY_ABORTED:
-        return result  # never retry safety aborts
+        return _failed("acquire_food", result)  # never retry safety aborts
     if not result:
-        return result
+        return _failed("acquire_food", result)
 
-    # 5. Extract food from plate
+    logger.info("feed_bite[%s]: extract_food", food.name)
     result = extract_food(schema, arm=arm, ctx=ctx)
     if not result:
-        return result
+        return _failed("extract_food", result)
 
-    # 6. Level fork for transport (best-effort — proceed even if leveling fails)
-    level_fork(arm=arm, ctx=ctx)
-
-    # 7. Detect mouth
-    mouth_pose = detect_mouth(robot)
-    if mouth_pose is None:
-        return failure(
-            FailureKind.PERCEPTION_FAILED,
-            "feed_bite:mouth_not_detected",
+    # level_fork is best-effort: proceed even if leveling fails.
+    logger.info("feed_bite[%s]: level_fork (best-effort)", food.name)
+    level_result = level_fork(arm=arm, ctx=ctx)
+    if not level_result:
+        logger.warning(
+            "feed_bite[%s]: level_fork failed (%s) — continuing",
+            food.name, level_result.failure_code or level_result.failure_kind,
         )
 
-    # 8. Move to mouth
+    logger.info("feed_bite[%s]: detect_mouth", food.name)
+    mouth_pose = detect_mouth(robot)
+    if mouth_pose is None:
+        return _failed("detect_mouth", failure(
+            FailureKind.PERCEPTION_FAILED,
+            "feed_bite:mouth_not_detected",
+        ))
+
+    logger.info("feed_bite[%s]: transfer_to_mouth", food.name)
     result = transfer_to_mouth(mouth_pose, arm=arm, ctx=ctx, fork_tsr=robot.fork_tsr)
     if not result:
-        return result
+        return _failed("transfer_to_mouth", result)
 
-    # 9. Wait for bite
+    logger.info("feed_bite[%s]: wait_for_bite", food.name)
     wait_for_bite(arm=arm, ctx=ctx, timeout=10.0)
 
-    # 10. Retract from mouth (along mouth approach axis)
+    logger.info("feed_bite[%s]: retract_from_mouth", food.name)
     retract_from_mouth(mouth_pose, arm=arm, ctx=ctx)
 
-    logger.info("Feed bite complete: %s", food.name)
+    logger.info("feed_bite[%s]: complete", food.name)
     return success(food=food.name)
 
 


### PR DESCRIPTION
## Summary
- The Outcome's \`failure_code\` names the underlying *behavior* (e.g. \`ft_guarded_move:no_progress\`), but three pipeline steps call \`ft_guarded_move\` (\`acquire_food\`, \`extract_food\`, \`transfer_to_mouth\`). The code alone doesn't tell the user which step blew up.
- Adds per-step \`logger.info\` on entry and \`logger.warning(\"feed_bite[<food>]: <step> failed (<code>)\")\` on failure. \`level_fork\` is best-effort: warn but continue.
- Matches the per-failure logging style of \`mj_manipulator\`/\`geodude\` primitives. No behavior change.

Fixes #39

## Sample output
\`\`\`
INFO  feed_bite[apple_0]: tare_ft
INFO  feed_bite[apple_0]: tilt_fork (45.0 deg)
INFO  feed_bite[apple_0]: move_above
INFO  feed_bite[apple_0]: acquire_food
WARN  feed_bite[apple_0]: acquire_food failed (ft_guarded_move:no_progress)
\`\`\`

## Test plan
- [x] Module imports cleanly.
- [x] \`ruff check\` passes.
- [ ] Re-run \`feed()\` in the console — failure log now identifies the failing step.