### PR TITLE
console: feeding-aware banner, drop inapplicable grasp primitives

### DIFF
--- a/src/ada_mj/console.py
+++ b/src/ada_mj/console.py
@@ -10,6 +10,7 @@ ADA-specific panels and namespace entries.
 from __future__ import annotations
 
 import logging
+import re
 from types import ModuleType
 from typing import TYPE_CHECKING
 
@@ -96,6 +97,11 @@ IPython:
         "go_to": lambda pose_name: robot.go_to(pose_name),
     }
 
+    # Banner lines advertising ADA commands. ADA has no gripper (welded tool),
+    # so the generic pickup/place/go_home primitives don't apply — we opt out
+    # of them below and advertise the demo helpers + go_to/commands instead.
+    banner_lines: list[str] = []
+
     # Wire in demo functions if a demo was loaded — same pattern as geodude.
     if demo_module is not None:
         from ada_mj.demo_loader import get_demo_functions, inject_robot
@@ -103,6 +109,17 @@ IPython:
         inject_robot(demo_module, robot)
         for fn_name, fn in get_demo_functions(demo_module).items():
             extra_ns[fn_name] = fn
+            doc = (fn.__doc__ or "").strip().split("\n", 1)[0].strip()
+            # Strip RST markup so docstrings read cleanly in the terminal:
+            # ":class:`FoodItem`" → "FoodItem", "``feed_bite``" → "feed_bite".
+            doc = re.sub(r":\w+:`([^`]*)`", r"\1", doc).replace("`", "")
+            if len(doc) > 46:
+                doc = doc[:45].rstrip() + "…"
+            banner_lines.append(f"  {fn_name + '()':<18}— {doc}")
+
+    banner_lines.append("  go_to('stow')     — move to a named pose")
+    banner_lines.append(f"  {'commands()':<18}— full ADA command reference")
+    extra_banner = "\n".join(banner_lines) + "\n"
 
     # -- Panel setup callback (same pattern as geodude) -------------------------
     def _setup_ada_panels(gui, viewer, robot, event_loop, tabs):
@@ -243,4 +260,6 @@ IPython:
         robot_name="ADA",
         extra_ns=extra_ns,
         panel_setup=_setup_ada_panels if viser else None,
+        grasp_primitives=False,
+        extra_banner=extra_banner,
     )


### PR DESCRIPTION
## Why
Launching the feeding demo printed the generic manipulation banner:
```
  pickup('object')  — pick up an object
  place('dest')     — place held object
  go_home()         — return to ready
```
These don't apply to ADA — it has no gripper (welded tool), so `pickup`/`place` would crash if called — and the actual feeding helpers (`feed`, `feed_all`, …) were injected into the namespace but never advertised.

## What
- Pass `grasp_primitives=False` to the generic console so pickup/place/go_home are dropped from the namespace **and** banner.
- Build `extra_banner` from the loaded demo's helper functions (name + cleaned one-line docstring) plus `go_to(...)` and a `commands()` pointer.

New banner for `--demo feeding`:
```
  feed()            — Run one feed_bite cycle.
  feed_all()        — Run feed_bite for each food item in order.
  food_items()      — Return a list of FoodItem for every food/* bo…
  move_above_food() — Just the pre-acquisition phase: tilt the fork…
  transfer()        — Just the mouth-transfer phase: TSR-plan to pl…
  go_to('stow')     — move to a named pose
  commands()        — full ADA command reference
  estop()           — E-Stop: halt everything
  release_estop()   — release E-Stop
  robot.<tab>       — tab completion
```

## Depends on
personalrobotics/mj_manipulator#166 (adds the `grasp_primitives` / `extra_banner` params). Works locally via the editable workspace install.

## Test plan
- Banner rendered against the real `feeding` demo module — verified format + RST-markup stripping.
- `ada_mj.console` imports clean.