### PR TITLE
observe_plate: CameraTSR staging config that frames the whole plate (Slice 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,6 @@ select = ["F", "E", "W", "I"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "slow: integration tests that load the full MuJoCo model and plan (deselect with '-m \"not slow\"')",
+]

--- a/scripts/validate_observe.py
+++ b/scripts/validate_observe.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Validate the observe_plate CameraTSR: is the whole plate inside the frustum?
+
+Two independent checks, both exit non-zero on failure (CI-ready):
+
+1. Closed-form framing math — the analytic ``min_standoff`` must place the
+   worst-case plate-rim point exactly on the FOV cone boundary (verified by
+   brute force over the rim), proving the formula is exact, not a heuristic.
+
+2. In-context TSR construction — build the real ``CameraTSR.observe`` templates,
+   instantiate them at the plate pose, sample poses across the look-at cone, and
+   confirm every sampled camera pose (a) keeps the optical axis through the plate
+   center, (b) tilts no more than ``tilt_max`` off vertical, and (c) projects the
+   entire *true* plate rim inside the camera's vertical FOV cone.
+
+Run::
+
+    uv run python scripts/validate_observe.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+import mujoco
+import numpy as np
+
+from ada_mj.config import ADAConfig
+from ada_mj.robot import ADA
+from ada_mj.scenes.table import PLATE_RADIUS
+
+TILTS_DEG = [0.0, 15.0, 30.0, 45.0]
+AXIS_EPS = 2e-3  # m: optical axis must pass within 2 mm of the plate center
+TILT_EPS = np.radians(0.5)  # rad: tilt magnitude slack
+
+
+def worst_rim_half_angle(R: float, d: float, tilt: float, n: int = 2000) -> float:
+    """Max angle between the optical axis and a plate-rim ray.
+
+    Camera at distance ``d`` from the plate center, looking at it, tilted
+    ``tilt`` off vertical. Plate is a disc of radius ``R`` in the z=0 plane.
+    """
+    u = np.array([np.sin(tilt), 0.0, np.cos(tilt)])
+    C = d * u
+    a = -u
+    al = np.linspace(0.0, 2.0 * np.pi, n, endpoint=False)
+    P = np.stack([R * np.cos(al), R * np.sin(al), np.zeros_like(al)], axis=1)
+    v = P - C
+    cosang = (v @ a) / np.linalg.norm(v, axis=1)
+    return float(np.arccos(np.clip(cosang, -1.0, 1.0)).max())
+
+
+def check_closed_form(cam_tsr, beta: float, frame_margin: float = 0.15) -> bool:
+    """The analytic d_min must drive the worst rim angle exactly to beta."""
+    r_eff = PLATE_RADIUS * (1.0 + frame_margin)
+    print("\n[1] Closed-form framing math (worst rim angle == fovy/2):")
+    ok = True
+    for tdeg in [0.0, 5.0, np.degrees(beta), 30.0, 45.0]:
+        t = np.radians(tdeg)
+        # min_standoff includes the frame margin; strip standoff_margin (0 here).
+        d = cam_tsr.min_standoff(PLATE_RADIUS, tilt=t, frame_margin=frame_margin)
+        wr = worst_rim_half_angle(r_eff, d, t)
+        err = np.degrees(wr - beta)
+        flag = "" if abs(err) < 0.05 else "  <-- MISMATCH"
+        ok = ok and abs(err) < 0.05
+        print(f"    tilt={tdeg:5.1f}°  d_min={d:.4f}m  worst_rim={np.degrees(wr):7.3f}°  err={err:+.4f}°{flag}")
+    print(f"    => {'PASS' if ok else 'FAIL'}")
+    return ok
+
+
+def check_tsr_in_context(robot, cam_tsr, plate_pose: np.ndarray, beta: float) -> bool:
+    """Sample the real TSR cone and verify framing of the true plate."""
+    from tsr.tsr import TSR
+
+    T_ee_cam = cam_tsr._get_T_ee_to_cam()
+    center = plate_pose[:3, 3]
+    down = np.array([0.0, 0.0, -1.0])
+
+    print("\n[2] In-context TSR construction (sampled poses frame the true plate):")
+    all_ok = True
+    for tdeg in TILTS_DEG:
+        tilt_max = np.radians(tdeg)
+        templates = cam_tsr.observe(PLATE_RADIUS, tilt_max=tilt_max)
+
+        worst_axis_err = 0.0
+        worst_tilt = 0.0
+        worst_rim = 0.0
+        n = 0
+        # Deterministic grid over the cone: every standoff template, pitch from
+        # 0..tilt_max, full azimuth ring. Hits the worst case (max tilt) exactly.
+        pitches = np.linspace(0.0, tilt_max, 4)
+        yaws = np.linspace(-np.pi, np.pi, 16, endpoint=False)
+        for tmpl in templates:
+            tsr = TSR(T0_w=plate_pose @ tmpl.T_ref_tsr, Tw_e=tmpl.Tw_e, Bw=tmpl.Bw)
+            for p in pitches:
+                for y in yaws:
+                    T_ee = tsr.to_transform([0.0, 0.0, 0.0, 0.0, p, y])
+                    T_cam = T_ee @ T_ee_cam
+                    C = T_cam[:3, 3]
+                    axis = -T_cam[:3, 2]  # MuJoCo camera looks down -z
+                    axis = axis / np.linalg.norm(axis)
+
+                    # (a) optical axis passes through the plate center
+                    w = center - C
+                    perp = np.linalg.norm(w - (w @ axis) * axis)
+                    worst_axis_err = max(worst_axis_err, perp)
+
+                    # (b) tilt of optical axis off vertical
+                    tilt = np.arccos(np.clip(axis @ down, -1.0, 1.0))
+                    worst_tilt = max(worst_tilt, tilt)
+
+                    # (c) true plate rim inside the fovy/2 cone
+                    al = np.linspace(0.0, 2.0 * np.pi, 360, endpoint=False)
+                    rim = center + PLATE_RADIUS * np.stack(
+                        [np.cos(al), np.sin(al), np.zeros_like(al)], axis=1
+                    )
+                    v = rim - C
+                    cosang = (v @ axis) / np.linalg.norm(v, axis=1)
+                    rim_ang = np.arccos(np.clip(cosang, -1.0, 1.0)).max()
+                    worst_rim = max(worst_rim, rim_ang)
+                    n += 1
+
+        ok = (
+            worst_axis_err <= AXIS_EPS
+            and worst_tilt <= tilt_max + TILT_EPS
+            and worst_rim <= beta + 1e-6
+        )
+        all_ok = all_ok and ok
+        print(
+            f"    tilt_max={tdeg:5.1f}°  n={n:4d}  "
+            f"axis_off_center<={worst_axis_err * 1e3:5.2f}mm  "
+            f"max_tilt={np.degrees(worst_tilt):5.2f}°  "
+            f"rim_angle={np.degrees(worst_rim):6.3f}° (fovy/2={np.degrees(beta):.2f}°)  "
+            f"{'PASS' if ok else 'FAIL'}"
+        )
+    print(f"    => {'PASS' if all_ok else 'FAIL'}")
+    return all_ok
+
+
+def main() -> int:
+    robot = ADA(ADAConfig.default())
+    mujoco.mj_forward(robot.model, robot.data)
+    cam_tsr = robot.camera_tsr
+    beta = cam_tsr.fovy / 2.0
+
+    sid = mujoco.mj_name2id(robot.model, mujoco.mjtObj.mjOBJ_SITE, "plate_center")
+    if sid < 0:
+        print("plate_center site not found — is the table scene loaded?")
+        return 2
+    plate_pose = np.eye(4)
+    plate_pose[:3, 3] = robot.data.site_xpos[sid].copy()
+
+    print(f"fovy = {np.degrees(cam_tsr.fovy):.1f}°   plate_radius = {PLATE_RADIUS} m")
+    ok1 = check_closed_form(cam_tsr, beta)
+    ok2 = check_tsr_in_context(robot, cam_tsr, plate_pose, beta)
+
+    print(f"\nRESULT: {'PASS' if (ok1 and ok2) else 'FAIL'}")
+    return 0 if (ok1 and ok2) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_observe.py
+++ b/scripts/validate_observe.py
@@ -30,7 +30,7 @@ import numpy as np
 
 from ada_mj.config import ADAConfig
 from ada_mj.robot import ADA
-from ada_mj.scenes.table import PLATE_RADIUS
+from ada_mj.scenes.table import PLATE_RADIUS, plate_pose
 
 TILTS_DEG = [0.0, 15.0, 30.0, 45.0]
 AXIS_EPS = 2e-3  # m: optical axis must pass within 2 mm of the plate center
@@ -71,15 +71,23 @@ def check_closed_form(cam_tsr, beta: float, frame_margin: float = 0.15) -> bool:
     return ok
 
 
-def check_tsr_in_context(robot, cam_tsr, plate_pose: np.ndarray, beta: float) -> bool:
-    """Sample the real TSR cone and verify framing of the true plate."""
+def check_tsr_algebra(robot, cam_tsr, plate_T: np.ndarray, beta: float) -> bool:
+    """Sample the TSR cone and verify the rotation ALGEBRA frames the plate.
+
+    NOTE: this reconstructs the camera as ``T_ee @ T_ee_cam``, where the same
+    ``T_ee_cam`` is baked (inverted) into ``Tw_e`` — so it cancels exactly and
+    this check sees the hand-authored canonical pose, NOT the real link_6→camera
+    mounting. It proves the Euler-box construction (axis stays on center, tilt
+    bounded by tilt_max) across the whole cone. The mounting itself is verified
+    independently in `check_executed_direct`, which reads MuJoCo FK.
+    """
     from tsr.tsr import TSR
 
     T_ee_cam = cam_tsr._get_T_ee_to_cam()
-    center = plate_pose[:3, 3]
+    center = plate_T[:3, 3]
     down = np.array([0.0, 0.0, -1.0])
 
-    print("\n[2] In-context TSR construction (sampled poses frame the true plate):")
+    print("\n[2] TSR rotation algebra (sampled cone keeps axis on center, tilt bounded):")
     all_ok = True
     for tdeg in TILTS_DEG:
         tilt_max = np.radians(tdeg)
@@ -94,7 +102,7 @@ def check_tsr_in_context(robot, cam_tsr, plate_pose: np.ndarray, beta: float) ->
         pitches = np.linspace(0.0, tilt_max, 4)
         yaws = np.linspace(-np.pi, np.pi, 16, endpoint=False)
         for tmpl in templates:
-            tsr = TSR(T0_w=plate_pose @ tmpl.T_ref_tsr, Tw_e=tmpl.Tw_e, Bw=tmpl.Bw)
+            tsr = TSR(T0_w=plate_T @ tmpl.T_ref_tsr, Tw_e=tmpl.Tw_e, Bw=tmpl.Bw)
             for p in pitches:
                 for y in yaws:
                     T_ee = tsr.to_transform([0.0, 0.0, 0.0, 0.0, p, y])
@@ -112,7 +120,7 @@ def check_tsr_in_context(robot, cam_tsr, plate_pose: np.ndarray, beta: float) ->
                     tilt = np.arccos(np.clip(axis @ down, -1.0, 1.0))
                     worst_tilt = max(worst_tilt, tilt)
 
-                    # (c) true plate rim inside the fovy/2 cone
+                    # (c) true plate rim inside the half-FOV cone
                     al = np.linspace(0.0, 2.0 * np.pi, 360, endpoint=False)
                     rim = center + PLATE_RADIUS * np.stack(
                         [np.cos(al), np.sin(al), np.zeros_like(al)], axis=1
@@ -133,9 +141,64 @@ def check_tsr_in_context(robot, cam_tsr, plate_pose: np.ndarray, beta: float) ->
             f"    tilt_max={tdeg:5.1f}°  n={n:4d}  "
             f"axis_off_center<={worst_axis_err * 1e3:5.2f}mm  "
             f"max_tilt={np.degrees(worst_tilt):5.2f}°  "
-            f"rim_angle={np.degrees(worst_rim):6.3f}° (fovy/2={np.degrees(beta):.2f}°)  "
+            f"rim_angle={np.degrees(worst_rim):6.3f}° (half_fov={np.degrees(beta):.2f}°)  "
             f"{'PASS' if ok else 'FAIL'}"
         )
+    print(f"    => {'PASS' if all_ok else 'FAIL'}")
+    return all_ok
+
+
+def check_executed_direct(robot, beta: float, frame_margin: float = 0.15) -> bool:
+    """Solve observe_plate, then read the camera straight from MuJoCo FK.
+
+    The independent oracle: the camera pose comes from MuJoCo's own forward
+    kinematics at the achieved config, so a bug in the EE→camera mounting
+    transform (which cancels in `check_tsr_algebra`) is caught here. Also
+    asserts the framing margin is actually present (rim well inside the cone),
+    not merely rim ≤ beta — closing the ~5° slack a bare containment check
+    would leave.
+    """
+    from ada_mj.feeding.behaviors import observe_plate
+
+    print("\n[3] Executed pose (camera read from MuJoCo FK — independent of T_ee_cam):")
+    pose = plate_pose(robot.model, robot.data)
+    center = pose[:3, 3]
+    cid = mujoco.mj_name2id(robot.model, mujoco.mjtObj.mjOBJ_CAMERA, "camera/d415_color")
+    expected = beta / (1.0 + frame_margin)
+    all_ok = True
+    with robot.sim(physics=False, headless=True) as ctx:
+        for tdeg in [0.0, 30.0]:
+            robot._observe_config = None  # force a fresh solve each tilt
+            robot.arm.set_joint_positions(robot.named_poses["above_plate"])
+            robot._snap_tool_to_weld()
+            mujoco.mj_forward(robot.model, robot.data)
+            res = observe_plate(
+                robot, ctx, plate_pose=pose, plate_radius=PLATE_RADIUS,
+                tilt_max=np.radians(tdeg),
+            )
+            if not res:
+                print(f"    tilt_max={tdeg:5.1f}°  PLAN FAILED ({res.failure_code})")
+                all_ok = False
+                continue
+            axis = -robot.data.cam_xmat[cid].reshape(3, 3)[:, 2]
+            axis = axis / np.linalg.norm(axis)
+            C = robot.data.cam_xpos[cid].copy()
+            w = center - C
+            perp = np.linalg.norm(w - (w @ axis) * axis)
+            al = np.linspace(0.0, 2.0 * np.pi, 360, endpoint=False)
+            rim = center + PLATE_RADIUS * np.stack(
+                [np.cos(al), np.sin(al), np.zeros_like(al)], axis=1
+            )
+            v = rim - C
+            rim_ang = np.arccos(np.clip((v @ axis) / np.linalg.norm(v, axis=1), -1, 1)).max()
+            ok = perp <= 3e-3 and rim_ang <= beta and rim_ang <= expected + np.radians(1.0)
+            all_ok = all_ok and ok
+            print(
+                f"    tilt_max={tdeg:5.1f}°  axis_off_center={perp * 1e3:5.2f}mm  "
+                f"rim_angle={np.degrees(rim_ang):6.3f}° "
+                f"(≤half_fov {np.degrees(beta):.2f}°, expect ≤{np.degrees(expected):.2f}°)  "
+                f"{'PASS' if ok else 'FAIL'}"
+            )
     print(f"    => {'PASS' if all_ok else 'FAIL'}")
     return all_ok
 
@@ -144,21 +207,24 @@ def main() -> int:
     robot = ADA(ADAConfig.default())
     mujoco.mj_forward(robot.model, robot.data)
     cam_tsr = robot.camera_tsr
-    beta = cam_tsr.fovy / 2.0
+    beta = cam_tsr.half_fov
 
-    sid = mujoco.mj_name2id(robot.model, mujoco.mjtObj.mjOBJ_SITE, "plate_center")
-    if sid < 0:
+    pose = plate_pose(robot.model, robot.data)
+    if pose is None:
         print("plate_center site not found — is the table scene loaded?")
         return 2
-    plate_pose = np.eye(4)
-    plate_pose[:3, 3] = robot.data.site_xpos[sid].copy()
 
-    print(f"fovy = {np.degrees(cam_tsr.fovy):.1f}°   plate_radius = {PLATE_RADIUS} m")
+    print(
+        f"fovy = {np.degrees(cam_tsr.fovy):.1f}°   "
+        f"half_fov = {np.degrees(beta):.2f}°   plate_radius = {PLATE_RADIUS} m"
+    )
     ok1 = check_closed_form(cam_tsr, beta)
-    ok2 = check_tsr_in_context(robot, cam_tsr, plate_pose, beta)
+    ok2 = check_tsr_algebra(robot, cam_tsr, pose, beta)
+    ok3 = check_executed_direct(robot, beta)
 
-    print(f"\nRESULT: {'PASS' if (ok1 and ok2) else 'FAIL'}")
-    return 0 if (ok1 and ok2) else 1
+    ok = ok1 and ok2 and ok3
+    print(f"\nRESULT: {'PASS' if ok else 'FAIL'}")
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":

--- a/src/ada_mj/demos/feeding.py
+++ b/src/ada_mj/demos/feeding.py
@@ -7,6 +7,9 @@ Helpers available in the console after launching with ``--demo feeding``:
 
   food_items()              — list of FoodItem instances for the food bodies
                               currently in the scene
+  observe(tilt_max=0)       — move to the observe_plate staging config: the
+                              camera framing the whole plate. Solves a CameraTSR
+                              once and caches the config; returns to it after.
   feed(food=None)           — run one feed_bite cycle for ``food`` (defaults
                               to the first food on the plate)
   feed_all()                — run feed_bite for each food item in order
@@ -53,6 +56,43 @@ def food_items():
         food_type = label.rsplit("_", 1)[0] if "_" in label else label
         items.append(FoodItem(name=name, position=pos, food_type=food_type))
     return items
+
+
+def observe(tilt_max=0.0, force_replan=False):
+    """Move to the ``observe_plate`` staging config — camera framing the plate.
+
+    Solves a CameraTSR over the plate (camera looking down at the plate center,
+    far enough that the whole plate fits the view), executes the plan, and
+    caches the achieved config for fast repeatable returns. After this,
+    ``robot.camera.render_color()`` shows the entire plate.
+
+    Args:
+        tilt_max: Half-angle (degrees) of the look-at cone off vertical. 0 →
+            straight-down-overhead. Widen if the overhead pose is unreachable.
+        force_replan: Re-solve the TSR even if a config is already cached.
+    """
+    import mujoco
+    import numpy as np
+
+    from ada_mj.feeding.behaviors import observe_plate
+    from ada_mj.scenes.table import PLATE_RADIUS
+
+    sid = mujoco.mj_name2id(robot.model, mujoco.mjtObj.mjOBJ_SITE, "plate_center")
+    if sid < 0:
+        print("No plate_center site — is the table scene loaded?")
+        return None
+    mujoco.mj_forward(robot.model, robot.data)
+    plate_pose = np.eye(4)
+    plate_pose[:3, 3] = robot.data.site_xpos[sid].copy()
+
+    return observe_plate(
+        robot,
+        robot._active_context,
+        plate_pose=plate_pose,
+        plate_radius=PLATE_RADIUS,
+        tilt_max=np.radians(tilt_max),
+        force_replan=force_replan,
+    )
 
 
 def feed(food=None, schema=None):

--- a/src/ada_mj/demos/feeding.py
+++ b/src/ada_mj/demos/feeding.py
@@ -71,24 +71,20 @@ def observe(tilt_max=0.0, force_replan=False):
             straight-down-overhead. Widen if the overhead pose is unreachable.
         force_replan: Re-solve the TSR even if a config is already cached.
     """
-    import mujoco
     import numpy as np
 
     from ada_mj.feeding.behaviors import observe_plate
-    from ada_mj.scenes.table import PLATE_RADIUS
+    from ada_mj.scenes.table import PLATE_RADIUS, plate_pose
 
-    sid = mujoco.mj_name2id(robot.model, mujoco.mjtObj.mjOBJ_SITE, "plate_center")
-    if sid < 0:
+    pose = plate_pose(robot.model, robot.data)
+    if pose is None:
         print("No plate_center site — is the table scene loaded?")
         return None
-    mujoco.mj_forward(robot.model, robot.data)
-    plate_pose = np.eye(4)
-    plate_pose[:3, 3] = robot.data.site_xpos[sid].copy()
 
     return observe_plate(
         robot,
         robot._active_context,
-        plate_pose=plate_pose,
+        plate_pose=pose,
         plate_radius=PLATE_RADIUS,
         tilt_max=np.radians(tilt_max),
         force_replan=force_replan,

--- a/src/ada_mj/feeding/behaviors.py
+++ b/src/ada_mj/feeding/behaviors.py
@@ -121,6 +121,75 @@ def move_above(
     )
 
 
+def observe_plate(
+    robot,
+    ctx: ExecutionContext,
+    *,
+    plate_pose: np.ndarray | None = None,
+    plate_radius: float | None = None,
+    tilt_max: float = 0.0,
+    force_replan: bool = False,
+) -> Outcome:
+    """Move to the ``observe_plate`` staging config — camera framing the plate.
+
+    The feeding loop returns here after each bite. The config is chosen so the
+    whole plate falls inside the wrist camera's view frustum, via a
+    ``CameraTSR`` (camera looking straight down at the plate center, far enough
+    that the plate fits the vertical FOV).
+
+    Solved once per session and cached on the robot: the first call plans into
+    the TSR region and records the achieved config; subsequent calls plan back
+    to that cached config. Returning to a fixed config gives a repeatable
+    camera view (consistent perception) and a fast, reliable replan.
+
+    Args:
+        robot: ADA robot (provides ``camera_tsr``, ``arm``, the cached config).
+        ctx: Execution context.
+        plate_pose: 4x4 world pose of the plate center (z-up). Required when
+            solving (no cached config yet, or ``force_replan``); ignored on the
+            cached-return fast path.
+        plate_radius: Plate radius (m). Required when solving.
+        tilt_max: Half-angle (rad) of the look-at cone off vertical. 0 →
+            straight-down-overhead (best view); widen as a reachability escape
+            hatch if the overhead pose is unreachable for the arm.
+        force_replan: Re-solve the TSR even if a config is cached (e.g. after
+            the plate is re-localized on hardware).
+    """
+    arm = robot.arm
+
+    # Fast path: replan back to the cached observe config.
+    if not force_replan and robot._observe_config is not None:
+        path = arm.plan_to_configuration(robot._observe_config)
+        if path is None:
+            return failure(FailureKind.PLANNING_FAILED, "observe_plate:return_no_path")
+        if ctx.execute(arm.retime(path)):
+            return success()
+        return failure(FailureKind.EXECUTION_FAILED, "observe_plate:return_execution_failed")
+
+    if plate_pose is None or plate_radius is None:
+        return failure(
+            FailureKind.PRECONDITION_FAILED,
+            "observe_plate:need_plate_geometry",
+        )
+
+    templates = robot.camera_tsr.observe(plate_radius=plate_radius, tilt_max=tilt_max)
+    goal_tsrs = [t.instantiate(plate_pose) for t in templates]
+
+    path = arm.plan_to_tsrs(goal_tsrs)
+    if path is None:
+        return failure(FailureKind.PLANNING_FAILED, "observe_plate:no_path")
+
+    if not ctx.execute(arm.retime(path)):
+        return failure(FailureKind.EXECUTION_FAILED, "observe_plate:execution_failed")
+
+    # Cache the achieved config and register it as a named pose so the loop
+    # (and robot.go_to) can return to the exact same camera view.
+    q_observe = arm.get_joint_positions().copy()
+    robot._observe_config = q_observe
+    robot.named_poses["observe_plate"] = q_observe
+    return success()
+
+
 def tilt_fork(angle: float, *, ctx: ExecutionContext) -> Outcome:
     """Set the articutool tilt angle.
 

--- a/src/ada_mj/feeding/behaviors.py
+++ b/src/ada_mj/feeding/behaviors.py
@@ -157,6 +157,12 @@ def observe_plate(
     """
     arm = robot.arm
 
+    if ctx is None:
+        return failure(
+            FailureKind.PRECONDITION_FAILED,
+            "observe_plate:no_context",
+        )
+
     # Fast path: replan back to the cached observe config.
     if not force_replan and robot._observe_config is not None:
         path = arm.plan_to_configuration(robot._observe_config)
@@ -182,11 +188,10 @@ def observe_plate(
     if not ctx.execute(arm.retime(path)):
         return failure(FailureKind.EXECUTION_FAILED, "observe_plate:execution_failed")
 
-    # Cache the achieved config and register it as a named pose so the loop
-    # (and robot.go_to) can return to the exact same camera view.
-    q_observe = arm.get_joint_positions().copy()
-    robot._observe_config = q_observe
-    robot.named_poses["observe_plate"] = q_observe
+    # Cache the achieved config so subsequent calls return to the exact same
+    # camera view. Kept off robot.named_poses, which is a fixed enum of static
+    # poses (go_to / demo_loader validate against it) — this config is dynamic.
+    robot._observe_config = arm.get_joint_positions().copy()
     return success()
 
 

--- a/src/ada_mj/feeding/camera_tsr.py
+++ b/src/ada_mj/feeding/camera_tsr.py
@@ -57,12 +57,12 @@ if TYPE_CHECKING:
     import mujoco
 
 
-def min_standoff_for_disc(disc_radius: float, fovy: float, *, tilt: float = 0.0) -> float:
+def min_standoff_for_disc(disc_radius: float, half_fov: float, *, tilt: float = 0.0) -> float:
     """Minimum standoff for a disc to fit a camera's FOV cone (closed form).
 
     A disc of radius ``disc_radius`` is viewed with the optical axis through its
     center, tilted ``tilt`` off the disc normal. Every rim point stays inside
-    the FOV cone of half-angle ``β = fovy/2`` when::
+    the FOV cone of half-angle ``β = half_fov`` when::
 
         d_min(θ) = disc_radius·(sinθ + cosθ/tanβ)   for θ ≤ β   (near rim governs)
                  = disc_radius/sinβ                  for θ > β   (rim tangent governs)
@@ -73,26 +73,25 @@ def min_standoff_for_disc(disc_radius: float, fovy: float, *, tilt: float = 0.0)
 
     Args:
         disc_radius: Disc radius (m).
-        fovy: Full vertical field of view (rad); ``β = fovy/2`` is the limiting
-            half-angle (the FOV's inscribed circle).
+        half_fov: Limiting half field-of-view (rad) — the FOV's inscribed
+            circle (``min(fovy, fovx)/2``), the only roll-invariant bound.
         tilt: Optical-axis tilt off the disc normal (rad).
 
     Returns:
         Minimum standoff distance (m).
     """
-    beta = fovy / 2.0
-    if tilt <= beta:
-        return disc_radius * (np.sin(tilt) + np.cos(tilt) / np.tan(beta))
-    return disc_radius / np.sin(beta)
+    if half_fov <= 0.0:
+        raise ValueError(f"half_fov must be positive, got {half_fov}")
+    if tilt <= half_fov:
+        return disc_radius * (np.sin(tilt) + np.cos(tilt) / np.tan(half_fov))
+    return disc_radius / np.sin(half_fov)
 
 
 class CameraTSR:
     """Generate TSR templates that frame the plate in the wrist camera.
 
-    Reads the EE-to-camera transform live from the MuJoCo model. Unlike the
-    fork tip, the camera is rigid relative to the EE, so this transform is
-    constant — but reading it live keeps the generator robust to model
-    changes (e.g. a recalibrated camera mount).
+    The camera is rigid relative to the EE (shares ``link_6``), so the
+    EE-to-camera transform is constant; it is computed once (lazily) and cached.
 
     Args:
         model: MuJoCo model.
@@ -114,6 +113,7 @@ class CameraTSR:
         self._data = data
         self._ee_site_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_SITE, ee_site_name)
         self._cam_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
+        self._T_ee_cam: np.ndarray | None = None  # constant; memoized on first use
 
         if self._ee_site_id < 0:
             raise ValueError(f"EE site '{ee_site_name}' not found")
@@ -123,7 +123,28 @@ class CameraTSR:
     @property
     def fovy(self) -> float:
         """Camera vertical field of view (radians)."""
-        return float(np.radians(self._model.cam_fovy[self._cam_id]))
+        fovy = float(np.radians(self._model.cam_fovy[self._cam_id]))
+        if fovy <= 0.0:
+            raise ValueError(f"camera fovy must be positive, got {np.degrees(fovy)}°")
+        return fovy
+
+    @property
+    def half_fov(self) -> float:
+        """Limiting half field-of-view (radians) — the FOV's inscribed circle.
+
+        With image-roll free, the only roll-invariant containment bound is the
+        circle inscribed in the FOV rectangle, i.e. ``min(fovy, fovx)/2``. The
+        horizontal FOV is derived from the sensor aspect:
+        ``tan(fovx/2) = (w/h)·tan(fovy/2)``. For a landscape sensor (w ≥ h, like
+        the D415's 1280×720) this is simply ``fovy/2``; computing it from the
+        actual resolution keeps the guarantee correct for any sensor.
+        """
+        half_v = self.fovy / 2.0
+        w, h = self._model.cam_resolution[self._cam_id]
+        if w <= 0 or h <= 0:
+            return half_v  # resolution unset → assume landscape (fovy limits)
+        half_h = float(np.arctan((w / h) * np.tan(half_v)))
+        return min(half_v, half_h)
 
     def min_standoff(
         self,
@@ -134,16 +155,10 @@ class CameraTSR:
     ) -> float:
         """Minimum camera standoff (m) for the whole plate to fit the frustum.
 
-        Closed form (see module docstring for the derivation). The plate is a
-        disc of radius ``R_eff = plate_radius·(1+frame_margin)``; with the
-        optical axis through the plate center, every rim point stays inside the
-        FOV cone of half-angle ``β = fovy/2`` when::
-
-            d_min(θ) = R_eff·(sinθ + cosθ/tanβ)   for θ ≤ β
-                     = R_eff/sinβ                  for θ > β
-
-        For ``θ > β`` the binding ray is tangent to the rim and the standoff
-        saturates at ``R_eff/sinβ`` — tilting further needs no extra distance.
+        Thin adapter over :func:`min_standoff_for_disc`: applies the framing
+        margin (``R_eff = plate_radius·(1+frame_margin)``) and supplies the
+        camera's limiting half-FOV (:attr:`half_fov`). See that function and the
+        module docstring for the closed form and its derivation.
 
         Args:
             plate_radius: Plate radius (m).
@@ -156,7 +171,7 @@ class CameraTSR:
             Minimum standoff distance ``d`` (m).
         """
         r_eff = plate_radius * (1.0 + frame_margin)
-        return min_standoff_for_disc(r_eff, self.fovy, tilt=tilt)
+        return min_standoff_for_disc(r_eff, self.half_fov, tilt=tilt)
 
     def _site_pose(self, site_id: int) -> np.ndarray:
         """Read a 4x4 pose from a MuJoCo site."""
@@ -173,18 +188,21 @@ class CameraTSR:
         return T
 
     def _get_T_ee_to_cam(self) -> np.ndarray:
-        """Compute the (constant) EE-to-camera transform from the model.
+        """The (constant) EE-to-camera transform, computed once and cached.
 
-        Runs forward kinematics so site and camera poses are consistent,
-        then returns ``inv(T_world_ee) @ T_world_cam``. The result is
-        independent of arm configuration (camera and EE share ``link_6``).
+        Camera and EE share ``link_6`` with no joint between them, so this
+        transform is configuration-independent. It is computed on first use —
+        running forward kinematics so site and camera poses are consistent — and
+        memoized, so repeat calls neither recompute nor mutate ``data``.
         """
-        import mujoco as mj
+        if self._T_ee_cam is None:
+            import mujoco as mj
 
-        mj.mj_forward(self._model, self._data)
-        T_world_ee = self._site_pose(self._ee_site_id)
-        T_world_cam = self._camera_pose()
-        return np.linalg.inv(T_world_ee) @ T_world_cam
+            mj.mj_forward(self._model, self._data)
+            T_world_ee = self._site_pose(self._ee_site_id)
+            T_world_cam = self._camera_pose()
+            self._T_ee_cam = np.linalg.inv(T_world_ee) @ T_world_cam
+        return self._T_ee_cam
 
     def observe(
         self,

--- a/src/ada_mj/feeding/camera_tsr.py
+++ b/src/ada_mj/feeding/camera_tsr.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Camera TSR generator for ADA plate observation.
+
+Generates TSRTemplates that place the wrist camera so the whole plate
+falls inside its view frustum — the ``observe_plate`` staging region the
+feeding loop returns to after each bite.
+
+The TSR constrains the *camera* pose (not the fork tip): a general "look-at"
+region in which the optical axis passes through the plate center from any
+direction within a cone of half-angle ``tilt_max`` off vertical, at a standoff
+far enough that the whole plate fits the view. ``Tw_e`` bakes in the inverse of
+``T_ee_to_cam`` so the planner gets EE targets. ``tilt_max=0`` degenerates to a
+single straight-down-overhead view.
+
+The camera is rigidly mounted on ``link_6`` (the same body as ``ee_site``,
+no intervening joints), so ``T_ee_to_cam`` is a constant — this is what lets us
+author the TSR in *camera space* (the natural space for a look-at constraint)
+and push it through a constant ``Tw_e`` to the EE-space region the planner
+solves. With a wrist-moving camera the offset would depend on configuration and
+this would not be possible. (Contrast ``ForkTSR``, whose EE→tip transform does
+change with the articutool joints — there the tilt is fixed before planning.)
+
+Geometry — the look-at cone (reference frame at the plate center):
+  Because the sampled displacement ``Δ`` (translations zeroed) is a pure
+  rotation about the reference origin, and the canonical optical axis already
+  points at that origin, EVERY sampled pose keeps the optical axis through the
+  plate center. The TSR's Euler box (``T0_e = T0_w·Trans·Rz(yaw)·Ry(pitch)·
+  Rx(roll)·Tw_e``) is used as: roll=0, pitch∈[0,tilt_max] (tilt magnitude,
+  since tilt = arccos(cos·roll·cos·pitch) = pitch when roll=0), yaw∈[-π,π] free
+  (azimuth orbit when tilted; image rotation when not — rotation about vertical
+  preserves tilt magnitude). No lateral translation: offsetting the optical
+  axis from the plate center would break the framing guarantee.
+
+Framing guarantee — minimum standoff for a disc of radius R at tilt θ, with
+``β = fovy/2`` the limiting half field-of-view:
+      d_min(θ) = R·(sinθ + cosθ/tanβ)   for θ ≤ β   (near rim governs)
+               = R/sinβ                  for θ > β   (rim tangent governs)
+  Derived from requiring every plate-rim point to fall inside the FOV cone of
+  half-angle β. β is the *inscribed* circle of the FOV rectangle (= fovy/2,
+  since the 1280×720 sensor makes the horizontal FOV wider): with yaw/image-roll
+  free, the rectangle rotates arbitrarily relative to the plate, so the largest
+  cone guaranteed inside it for all rolls is exactly that inscribed circle.
+
+This is ADA-specific (lives in ada_mj, not the tsr repo).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tsr.template import TSRTemplate
+
+if TYPE_CHECKING:
+    import mujoco
+
+
+def min_standoff_for_disc(disc_radius: float, fovy: float, *, tilt: float = 0.0) -> float:
+    """Minimum standoff for a disc to fit a camera's FOV cone (closed form).
+
+    A disc of radius ``disc_radius`` is viewed with the optical axis through its
+    center, tilted ``tilt`` off the disc normal. Every rim point stays inside
+    the FOV cone of half-angle ``β = fovy/2`` when::
+
+        d_min(θ) = disc_radius·(sinθ + cosθ/tanβ)   for θ ≤ β   (near rim governs)
+                 = disc_radius/sinβ                  for θ > β   (rim tangent governs)
+
+    Continuous at ``θ = β`` and saturating beyond it. Derived by maximizing the
+    rim-point angle over the disc; see the module docstring. Pure geometry — no
+    model, no margins (pass an already-inflated radius for a framing margin).
+
+    Args:
+        disc_radius: Disc radius (m).
+        fovy: Full vertical field of view (rad); ``β = fovy/2`` is the limiting
+            half-angle (the FOV's inscribed circle).
+        tilt: Optical-axis tilt off the disc normal (rad).
+
+    Returns:
+        Minimum standoff distance (m).
+    """
+    beta = fovy / 2.0
+    if tilt <= beta:
+        return disc_radius * (np.sin(tilt) + np.cos(tilt) / np.tan(beta))
+    return disc_radius / np.sin(beta)
+
+
+class CameraTSR:
+    """Generate TSR templates that frame the plate in the wrist camera.
+
+    Reads the EE-to-camera transform live from the MuJoCo model. Unlike the
+    fork tip, the camera is rigid relative to the EE, so this transform is
+    constant — but reading it live keeps the generator robust to model
+    changes (e.g. a recalibrated camera mount).
+
+    Args:
+        model: MuJoCo model.
+        data: MuJoCo data.
+        ee_site_name: Name of the EE site (on the arm kinematic chain).
+        camera_name: Name of the MuJoCo camera (color optical frame).
+    """
+
+    def __init__(
+        self,
+        model: mujoco.MjModel,
+        data: mujoco.MjData,
+        ee_site_name: str = "ee_site",
+        camera_name: str = "camera/d415_color",
+    ):
+        import mujoco as mj
+
+        self._model = model
+        self._data = data
+        self._ee_site_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_SITE, ee_site_name)
+        self._cam_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
+
+        if self._ee_site_id < 0:
+            raise ValueError(f"EE site '{ee_site_name}' not found")
+        if self._cam_id < 0:
+            raise ValueError(f"Camera '{camera_name}' not found")
+
+    @property
+    def fovy(self) -> float:
+        """Camera vertical field of view (radians)."""
+        return float(np.radians(self._model.cam_fovy[self._cam_id]))
+
+    def min_standoff(
+        self,
+        plate_radius: float,
+        *,
+        tilt: float = 0.0,
+        frame_margin: float = 0.15,
+    ) -> float:
+        """Minimum camera standoff (m) for the whole plate to fit the frustum.
+
+        Closed form (see module docstring for the derivation). The plate is a
+        disc of radius ``R_eff = plate_radius·(1+frame_margin)``; with the
+        optical axis through the plate center, every rim point stays inside the
+        FOV cone of half-angle ``β = fovy/2`` when::
+
+            d_min(θ) = R_eff·(sinθ + cosθ/tanβ)   for θ ≤ β
+                     = R_eff/sinβ                  for θ > β
+
+        For ``θ > β`` the binding ray is tangent to the rim and the standoff
+        saturates at ``R_eff/sinβ`` — tilting further needs no extra distance.
+
+        Args:
+            plate_radius: Plate radius (m).
+            tilt: Camera tilt off vertical (rad). The guarantee must hold for
+                the *largest* tilt the TSR permits, so pass ``tilt_max`` here.
+            frame_margin: Fractional border to leave around the plate
+                (0.15 → plate occupies at most ~87% of the limiting dimension).
+
+        Returns:
+            Minimum standoff distance ``d`` (m).
+        """
+        r_eff = plate_radius * (1.0 + frame_margin)
+        return min_standoff_for_disc(r_eff, self.fovy, tilt=tilt)
+
+    def _site_pose(self, site_id: int) -> np.ndarray:
+        """Read a 4x4 pose from a MuJoCo site."""
+        T = np.eye(4)
+        T[:3, :3] = self._data.site_xmat[site_id].reshape(3, 3)
+        T[:3, 3] = self._data.site_xpos[site_id]
+        return T
+
+    def _camera_pose(self) -> np.ndarray:
+        """Read the camera's 4x4 world pose (MuJoCo -z = view direction)."""
+        T = np.eye(4)
+        T[:3, :3] = self._data.cam_xmat[self._cam_id].reshape(3, 3)
+        T[:3, 3] = self._data.cam_xpos[self._cam_id]
+        return T
+
+    def _get_T_ee_to_cam(self) -> np.ndarray:
+        """Compute the (constant) EE-to-camera transform from the model.
+
+        Runs forward kinematics so site and camera poses are consistent,
+        then returns ``inv(T_world_ee) @ T_world_cam``. The result is
+        independent of arm configuration (camera and EE share ``link_6``).
+        """
+        import mujoco as mj
+
+        mj.mj_forward(self._model, self._data)
+        T_world_ee = self._site_pose(self._ee_site_id)
+        T_world_cam = self._camera_pose()
+        return np.linalg.inv(T_world_ee) @ T_world_cam
+
+    def observe(
+        self,
+        plate_radius: float,
+        *,
+        tilt_max: float = 0.0,
+        frame_margin: float = 0.15,
+        standoff_margin: float = 0.05,
+        standoff_range: float = 0.10,
+        k: int = 3,
+    ) -> list[TSRTemplate]:
+        """TSR templates for the camera framing the whole plate (look-at cone).
+
+        The reference frame is the plate center (z up). At ``Bw = 0`` the camera
+        sits at ``[0, 0, d]`` looking straight down (MuJoCo camera -z = view
+        direction = world -z), optical axis through the plate center. The Euler
+        box opens this into a look-at cone (see module docstring for why each
+        sampled pose keeps the axis on the plate center):
+
+        - x, y, z: 0 (z standoff baked per template; no lateral offset, which
+          would move the optical axis off center and break the guarantee)
+        - roll: 0 (keeps tilt magnitude exactly equal to pitch)
+        - pitch: ``[0, tilt_max]`` — tilt of the optical axis off vertical
+        - yaw: ``[-π, π]`` — azimuth orbit (when tilted) / image rotation
+
+        Standoff is sized for the *worst-case* tilt (``tilt_max``), so every
+        sampled view in the cone frames the whole plate. ``tilt_max=0`` yields a
+        single straight-down-overhead view (best for perception); a larger cone
+        trades view quality for reachability.
+
+        Args:
+            plate_radius: Plate radius (m).
+            tilt_max: Half-angle (rad) of the look-at cone off vertical. 0 →
+                straight down only.
+            frame_margin: Fractional border to leave around the plate.
+            standoff_margin: Extra standoff (m) beyond the geometric minimum.
+            standoff_range: Span (m) of standoff levels above ``d_min``.
+            k: Number of standoff levels to generate.
+
+        Returns:
+            List of TSRTemplates. Instantiate each with the plate's world pose.
+        """
+        d_min = (
+            self.min_standoff(plate_radius, tilt=tilt_max, frame_margin=frame_margin)
+            + standoff_margin
+        )
+
+        # T_ee_to_cam is constant; T_cam_to_ee composes the canonical camera
+        # pose (in plate frame) into the EE target the planner solves for.
+        T_cam_ee = np.linalg.inv(self._get_T_ee_to_cam())
+
+        # Canonical camera pose in plate frame: identity rotation places
+        # z_cam = +z_plate (= world up), so -z_cam (view direction) points
+        # down at the plate. Position is set per standoff level below.
+        Bw = np.array(
+            [
+                [0.0, 0.0],  # x: no lateral offset
+                [0.0, 0.0],  # y: no lateral offset
+                [0.0, 0.0],  # z: fixed at the template's standoff
+                [0.0, 0.0],  # roll: fixed → tilt magnitude == pitch
+                [0.0, tilt_max],  # pitch: tilt off vertical (the look-at cone)
+                [-np.pi, np.pi],  # yaw: azimuth orbit / image rotation
+            ]
+        )
+
+        templates = []
+        standoffs = np.linspace(d_min, d_min + standoff_range, max(k, 1))
+        for d in standoffs:
+            T_plate_cam = np.eye(4)
+            T_plate_cam[2, 3] = d
+            Tw_e = T_plate_cam @ T_cam_ee
+
+            templates.append(
+                TSRTemplate(
+                    T_ref_tsr=np.eye(4),
+                    Tw_e=Tw_e,
+                    Bw=Bw,
+                    task="observe",
+                    subject="camera",
+                    reference="plate",
+                    name=f"Camera over plate — {d * 100:.0f}cm",
+                    description=f"Camera {d * 100:.1f}cm from plate center, "
+                    f"look-at, tilt ≤{np.degrees(tilt_max):.0f}°, yaw free",
+                )
+            )
+
+        return templates

--- a/src/ada_mj/robot.py
+++ b/src/ada_mj/robot.py
@@ -131,6 +131,12 @@ class ADA:
         # Fork TSR generator — constructed lazily on first use via .fork_tsr
         self._fork_tsr = None
 
+        # Camera TSR generator (lazy) + cached observe_plate config. The
+        # config is solved once per session by feeding.behaviors.observe_plate
+        # and reused as a fast, repeatable return target between bites.
+        self._camera_tsr = None
+        self._observe_config: np.ndarray | None = None
+
         # Wrist camera (if camera present)
         self._camera = None
         if self.config.with_camera:
@@ -263,6 +269,27 @@ class ADA:
                 tip_site_name=f"{self.config.tool}/fork_tip",
             )
         return self._fork_tsr
+
+    @property
+    def camera_tsr(self):
+        """Camera TSR generator (lazy, cached).
+
+        Builds TSR templates that frame the whole plate in the wrist camera
+        for ``observe_plate``. Requires a wrist camera — raises ``ValueError``
+        otherwise.
+        """
+        if self._camera_tsr is None:
+            if self._camera is None:
+                raise ValueError("camera_tsr requires a wrist camera (with_camera=True)")
+            from ada_mj.feeding.camera_tsr import CameraTSR
+
+            self._camera_tsr = CameraTSR(
+                model=self.model,
+                data=self.data,
+                ee_site_name=self.config.ee_site,
+                camera_name=self.config.camera.color_camera,
+            )
+        return self._camera_tsr
 
     @property
     def named_poses(self) -> dict[str, np.ndarray]:

--- a/src/ada_mj/robot.py
+++ b/src/ada_mj/robot.py
@@ -429,6 +429,10 @@ class ADA:
         Deactivates teleop, aborts running trajectories, resets MuJoCo
         state, and syncs the controller to the new positions.
         """
+        # The cached observe_plate config is tied to the pre-reset state
+        # (arm + plate); invalidate it so the next observe_plate re-solves.
+        self._observe_config = None
+
         ctx = self._active_context
         if ctx is not None:
             ctx.reset_to_keyframe("stow")

--- a/src/ada_mj/scenes/table.py
+++ b/src/ada_mj/scenes/table.py
@@ -40,6 +40,28 @@ TABLE_SURFACE_HEIGHT = 0.735  # from prl_assets/ada_table/meta.yaml
 PLATE_RADIUS = 0.133
 PLATE_HEIGHT = 0.027
 
+# Name of the plate-center site (top surface, z-up) added in _add_table_and_plate.
+PLATE_CENTER_SITE = "plate_center"
+
+
+def plate_pose(model, data) -> np.ndarray | None:
+    """World pose (4x4) of the plate-center site, or ``None`` if absent.
+
+    Returns the full site frame — orientation included, not just translation —
+    so callers honor a tilted plate's actual disc normal (the framing standoff
+    is sized relative to that normal). Runs forward kinematics so the read
+    reflects the current state. Shared by the feeding loop, the ``observe``
+    demo helper, and ``scripts/validate_observe.py``.
+    """
+    sid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, PLATE_CENTER_SITE)
+    if sid < 0:
+        return None
+    mujoco.mj_forward(model, data)
+    T = np.eye(4)
+    T[:3, :3] = data.site_xmat[sid].reshape(3, 3)
+    T[:3, 3] = data.site_xpos[sid]
+    return T
+
 # Usable half-extents of the table surface for placement sampling.
 # The table mesh is 1.85 × 0.74 m but the C-shape leaves a smaller usable
 # rectangle near the user. Conservative half-extents keep the plate centered.

--- a/tests/test_camera_tsr.py
+++ b/tests/test_camera_tsr.py
@@ -32,16 +32,15 @@ def _worst_rim_half_angle(R: float, d: float, tilt: float, n: int = 4000) -> flo
     return float(np.arccos(np.clip(cosang, -1.0, 1.0)).max())
 
 
-@pytest.mark.parametrize("fovy_deg", [43.0, 60.0, 90.0])
+@pytest.mark.parametrize("beta_deg", [21.5, 30.0, 45.0])
 @pytest.mark.parametrize("tilt_deg", [0.0, 5.0, 15.0, 30.0, 45.0, 60.0])
-def test_min_standoff_puts_worst_rim_on_fov_boundary(fovy_deg, tilt_deg):
-    """d_min must drive the worst rim angle exactly to beta = fovy/2."""
+def test_min_standoff_puts_worst_rim_on_fov_boundary(beta_deg, tilt_deg):
+    """d_min must drive the worst rim angle exactly to the half-FOV beta."""
     R = 0.133
-    fovy = np.radians(fovy_deg)
-    beta = fovy / 2.0
+    beta = np.radians(beta_deg)
     tilt = np.radians(tilt_deg)
 
-    d = min_standoff_for_disc(R, fovy, tilt=tilt)
+    d = min_standoff_for_disc(R, beta, tilt=tilt)
     worst = _worst_rim_half_angle(R, d, tilt)
 
     # The binding rim point sits exactly on the FOV cone (never outside).
@@ -49,27 +48,89 @@ def test_min_standoff_puts_worst_rim_on_fov_boundary(fovy_deg, tilt_deg):
 
 
 def test_straight_down_matches_simple_formula():
-    """At zero tilt the standoff reduces to R / tan(fovy/2)."""
-    R, fovy = 0.133, np.radians(43.0)
-    assert min_standoff_for_disc(R, fovy, tilt=0.0) == pytest.approx(
-        R / np.tan(fovy / 2.0)
-    )
+    """At zero tilt the standoff reduces to R / tan(beta)."""
+    R, beta = 0.133, np.radians(21.5)
+    assert min_standoff_for_disc(R, beta, tilt=0.0) == pytest.approx(R / np.tan(beta))
 
 
 def test_standoff_saturates_beyond_beta():
     """For tilt > beta the standoff is constant at R / sin(beta)."""
-    R, fovy = 0.133, np.radians(43.0)
-    beta = fovy / 2.0
+    R, beta = 0.133, np.radians(21.5)
     saturated = R / np.sin(beta)
     for tilt_deg in [22.0, 30.0, 45.0, 70.0]:
-        assert min_standoff_for_disc(R, fovy, tilt=np.radians(tilt_deg)) == pytest.approx(
+        assert min_standoff_for_disc(R, beta, tilt=np.radians(tilt_deg)) == pytest.approx(
             saturated
         )
 
 
 def test_standoff_monotone_nondecreasing_in_tilt():
     """More tilt never requires less standoff."""
-    R, fovy = 0.133, np.radians(43.0)
+    R, beta = 0.133, np.radians(21.5)
     tilts = np.radians(np.linspace(0.0, 80.0, 50))
-    ds = [min_standoff_for_disc(R, fovy, tilt=t) for t in tilts]
+    ds = [min_standoff_for_disc(R, beta, tilt=t) for t in tilts]
     assert all(b >= a - 1e-12 for a, b in zip(ds, ds[1:]))
+
+
+def test_nonpositive_half_fov_raises():
+    """A degenerate (zero/negative) FOV must raise, not silently return inf."""
+    with pytest.raises(ValueError):
+        min_standoff_for_disc(0.133, 0.0)
+
+
+@pytest.mark.slow
+def test_observe_plate_frames_plate_via_direct_camera_read():
+    """End-to-end, independent of _get_T_ee_to_cam: solve observe_plate, then
+    read the camera pose straight from MuJoCo FK and confirm the whole real
+    plate projects inside the FOV cone with the intended framing margin.
+
+    This is the oracle the validator's algebraic check cannot be: the camera
+    pose comes from MuJoCo's own forward kinematics, so a bug in the EE→camera
+    transform (which cancels in T_ee @ T_ee_cam) would be caught here.
+    """
+    import mujoco
+
+    from ada_mj.config import ADAConfig
+    from ada_mj.feeding.behaviors import observe_plate
+    from ada_mj.scenes.table import PLATE_RADIUS, plate_pose
+
+    ADA = pytest.importorskip("ada_mj.robot").ADA
+    robot = ADA(ADAConfig.default())
+    pose = plate_pose(robot.model, robot.data)
+    assert pose is not None, "table scene must provide a plate_center site"
+    center = pose[:3, 3]
+    beta = robot.camera_tsr.half_fov
+    frame_margin = 0.15  # observe()'s default → expected framing headroom
+
+    with robot.sim(physics=False, headless=True) as ctx:
+        robot.arm.set_joint_positions(robot.named_poses["above_plate"])
+        robot._snap_tool_to_weld()
+        mujoco.mj_forward(robot.model, robot.data)
+        res = observe_plate(robot, ctx, plate_pose=pose, plate_radius=PLATE_RADIUS)
+        assert res, f"observe_plate failed: {res.failure_code}"
+
+        # Independent read: camera pose from MuJoCo FK at the achieved config.
+        cid = mujoco.mj_name2id(
+            robot.model, mujoco.mjtObj.mjOBJ_CAMERA, "camera/d415_color"
+        )
+        axis = -robot.data.cam_xmat[cid].reshape(3, 3)[:, 2]
+        axis = axis / np.linalg.norm(axis)
+        C = robot.data.cam_xpos[cid].copy()
+
+        # Optical axis passes through the plate center.
+        w = center - C
+        perp = np.linalg.norm(w - (w @ axis) * axis)
+        assert perp <= 3e-3, f"optical axis {perp * 1e3:.1f} mm off plate center"
+
+        # The whole TRUE plate rim is inside the FOV cone — and tighter than
+        # beta by the framing margin (guards against silent under-framing).
+        al = np.linspace(0.0, 2.0 * np.pi, 360, endpoint=False)
+        rim = center + PLATE_RADIUS * np.stack(
+            [np.cos(al), np.sin(al), np.zeros_like(al)], axis=1
+        )
+        v = rim - C
+        rim_ang = np.arccos(np.clip((v @ axis) / np.linalg.norm(v, axis=1), -1, 1)).max()
+        assert rim_ang <= beta, f"plate rim {np.degrees(rim_ang):.2f}° exceeds FOV {np.degrees(beta):.2f}°"
+        assert rim_ang <= beta / (1.0 + frame_margin) + np.radians(1.0), (
+            f"framing margin missing: rim {np.degrees(rim_ang):.2f}° not within "
+            f"expected {np.degrees(beta / (1.0 + frame_margin)):.2f}°"
+        )

--- a/tests/test_camera_tsr.py
+++ b/tests/test_camera_tsr.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Tests for the observe_plate framing geometry (CameraTSR).
+
+Guards the invariant the whole feature rests on: the closed-form minimum
+standoff must place the worst-case disc-rim point exactly on the FOV cone
+boundary — i.e. the formula is exact, not a heuristic. Pure geometry, no model.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ada_mj.feeding.camera_tsr import min_standoff_for_disc
+
+
+def _worst_rim_half_angle(R: float, d: float, tilt: float, n: int = 4000) -> float:
+    """Brute-force max angle between optical axis and a disc-rim ray.
+
+    Camera at distance ``d`` from the disc center, looking at it, tilted
+    ``tilt`` off the disc normal. Disc of radius ``R`` in the z=0 plane.
+    """
+    u = np.array([np.sin(tilt), 0.0, np.cos(tilt)])
+    C = d * u
+    a = -u
+    al = np.linspace(0.0, 2.0 * np.pi, n, endpoint=False)
+    P = np.stack([R * np.cos(al), R * np.sin(al), np.zeros_like(al)], axis=1)
+    v = P - C
+    cosang = (v @ a) / np.linalg.norm(v, axis=1)
+    return float(np.arccos(np.clip(cosang, -1.0, 1.0)).max())
+
+
+@pytest.mark.parametrize("fovy_deg", [43.0, 60.0, 90.0])
+@pytest.mark.parametrize("tilt_deg", [0.0, 5.0, 15.0, 30.0, 45.0, 60.0])
+def test_min_standoff_puts_worst_rim_on_fov_boundary(fovy_deg, tilt_deg):
+    """d_min must drive the worst rim angle exactly to beta = fovy/2."""
+    R = 0.133
+    fovy = np.radians(fovy_deg)
+    beta = fovy / 2.0
+    tilt = np.radians(tilt_deg)
+
+    d = min_standoff_for_disc(R, fovy, tilt=tilt)
+    worst = _worst_rim_half_angle(R, d, tilt)
+
+    # The binding rim point sits exactly on the FOV cone (never outside).
+    assert worst == pytest.approx(beta, abs=np.radians(0.05))
+
+
+def test_straight_down_matches_simple_formula():
+    """At zero tilt the standoff reduces to R / tan(fovy/2)."""
+    R, fovy = 0.133, np.radians(43.0)
+    assert min_standoff_for_disc(R, fovy, tilt=0.0) == pytest.approx(
+        R / np.tan(fovy / 2.0)
+    )
+
+
+def test_standoff_saturates_beyond_beta():
+    """For tilt > beta the standoff is constant at R / sin(beta)."""
+    R, fovy = 0.133, np.radians(43.0)
+    beta = fovy / 2.0
+    saturated = R / np.sin(beta)
+    for tilt_deg in [22.0, 30.0, 45.0, 70.0]:
+        assert min_standoff_for_disc(R, fovy, tilt=np.radians(tilt_deg)) == pytest.approx(
+            saturated
+        )
+
+
+def test_standoff_monotone_nondecreasing_in_tilt():
+    """More tilt never requires less standoff."""
+    R, fovy = 0.133, np.radians(43.0)
+    tilts = np.radians(np.linspace(0.0, 80.0, 50))
+    ds = [min_standoff_for_disc(R, fovy, tilt=t) for t in tilts]
+    assert all(b >= a - 1e-12 for a, b in zip(ds, ds[1:]))


### PR DESCRIPTION
First slice of the observe→bite→return feeding loop (#42).

## What
A new `observe_plate` staging config the feeding loop will return to after each bite — chosen so the **entire plate falls inside the wrist camera's frustum**, instead of the current hand-tuned `above_plate` constant with no framing guarantee.

- **`CameraTSR`** (`feeding/camera_tsr.py`) — a general *look-at* TSR: wrist-camera poses whose optical axis passes through the plate center from within a cone of half-angle `tilt_max` off vertical, at a standoff that keeps the whole plate framed. `tilt_max=0` (default) = straight-down-overhead (best for perception); widening is a reachability escape hatch.
- **`observe_plate`** behavior — solves the TSR once, caches the achieved config, and returns to it on subsequent calls (repeatable view → consistent perception; fast, reliable replan).
- Wiring: `robot.camera_tsr` property + cached `_observe_config`; `observe()` demo helper.

## Why the rigid camera matters
The camera is rigidly on `link_6` (no intervening joints), so `T_ee_to_cam` is **constant**. That's what lets us author the TSR in *camera space* (the natural space for a look-at) and push it to the EE-space region the planner solves via a constant `Tw_e`. A wrist-moving camera couldn't be expressed this way.

## Framing guarantee — exact, not heuristic
```
d_min(θ) = R_eff·(sinθ + cosθ/tanβ)   for θ ≤ β
         = R_eff/sinβ                  for θ > β     (saturates)
```
with `β = fovy/2`, the FOV's **inscribed circle** — the only roll-invariant bound, since yaw/image-roll is free. Derived by maximizing the rim-point angle (the binding ray is the near rim for small tilt, the rim *tangent* for large tilt).

## Verification
- **Closed-form proven exact**: brute force over the rim shows the worst-case point lands on the FOV boundary to <0.0001° at every tilt (`scripts/validate_observe.py`, CI-ready, exits non-zero on failure).
- **TSR construction proven in-context**: across the full cone (tilt_max up to 45°), optical axis through plate center to **0.00 mm**, tilt magnitude exactly `tilt_max`, true plate rim ≤16.9° vs the 21.5° FOV cone.
- **End to end**: straight-down is reachable for the JACO2; the *achieved* config frames the plate; cache-return is exact.
- **Unit tests** (`tests/test_camera_tsr.py`, 21 cases) guard the framing invariant against brute force across fovy/tilt.

## Not in this slice
Slice 2 — restructure `feeding_demo` into observe→bite→return with food consumption (so re-detection terminates). `feed_bite` is unchanged here.

Part of #42.