### PR TITLE
feeding_session: observe → detect → bite → consume loop (Slice 2)

### DIFF
--- a/src/ada_mj/demos/feeding.py
+++ b/src/ada_mj/demos/feeding.py
@@ -12,7 +12,8 @@ Helpers available in the console after launching with ``--demo feeding``:
                               once and caches the config; returns to it after.
   feed(food=None)           — run one feed_bite cycle for ``food`` (defaults
                               to the first food on the plate)
-  feed_all()                — run feed_bite for each food item in order
+  feed_all()                — full session: observe → bite → re-observe until
+                              the plate is clear (hides each eaten item)
   move_above_food(food=None)— just the pre-acquisition phase (TSR-plan the
                               fork tip above a food item, schema-tilted)
   transfer(plan=0.15, servo=0.10)
@@ -35,27 +36,27 @@ scene = {
 }
 
 
-def food_items():
-    """Return a list of :class:`FoodItem` for every ``food/*`` body in the scene.
+def _on_data_thread(fn):
+    """Run ``fn`` on the thread that owns MuJoCo ``data``.
 
-    Reads positions from the live MuJoCo state, so the list always reflects
-    the current state of the plate.
+    Reads/writes of live state (detect, hide) must happen on the physics
+    owner thread. ``run_on_physics_thread`` runs ``fn`` directly when already
+    there (the console/tick-driven case) and marshals it otherwise.
     """
-    import mujoco
+    ctx = robot._active_context
+    el = getattr(ctx, "_event_loop", None) if ctx is not None else None
+    return el.run_on_physics_thread(fn) if el is not None else fn()
 
-    from ada_mj.feeding.domain import FoodItem
 
-    items = []
-    for bid in range(robot.model.nbody):
-        name = mujoco.mj_id2name(robot.model, mujoco.mjtObj.mjOBJ_BODY, bid) or ""
-        if not name.startswith("food/"):
-            continue
-        pos = robot.data.xpos[bid].copy()
-        # name format: "food/<label>_<idx>" — strip trailing _idx for food_type
-        label = name.split("/", 1)[1]
-        food_type = label.rsplit("_", 1)[0] if "_" in label else label
-        items.append(FoodItem(name=name, position=pos, food_type=food_type))
-    return items
+def food_items():
+    """Return the :class:`FoodItem` list currently on the plate.
+
+    Reflects live MuJoCo state, so eaten items (hidden by the feeding loop) no
+    longer appear.
+    """
+    from ada_mj.scenes.table import detect_food
+
+    return _on_data_thread(lambda: detect_food(robot.model, robot.data))
 
 
 def observe(tilt_max=0.0, force_replan=False):
@@ -110,11 +111,38 @@ def feed(food=None, schema=None):
     return feed_bite(food, schema, robot=robot, ctx=robot._active_context)
 
 
-def feed_all():
-    """Run ``feed_bite`` for each food item in order."""
-    from ada_mj.feeding.task import feeding_demo
+def feed_all(tilt_max=0.0):
+    """Run the full feeding session: observe → bite → re-observe until clear.
 
-    return feeding_demo(food_items(), robot=robot, ctx=robot._active_context)
+    Returns to the plate-framing observe pose after each bite and re-detects,
+    hiding each eaten item so the loop terminates when the plate is clear.
+
+    Args:
+        tilt_max: Look-at cone half-angle (degrees) for the observe pose.
+    """
+    import numpy as np
+
+    from ada_mj.feeding.task import feeding_session
+    from ada_mj.scenes.table import PLATE_RADIUS, detect_food, hide_food, plate_pose
+
+    pose = _on_data_thread(lambda: plate_pose(robot.model, robot.data))
+    if pose is None:
+        print("No plate_center site — is the table scene loaded?")
+        return None
+
+    return feeding_session(
+        robot,
+        robot._active_context,
+        detect_food=lambda: _on_data_thread(
+            lambda: detect_food(robot.model, robot.data)
+        ),
+        consume_food=lambda food: _on_data_thread(
+            lambda: hide_food(robot.model, robot.data, food.name)
+        ),
+        plate_pose=pose,
+        plate_radius=PLATE_RADIUS,
+        tilt_max=np.radians(tilt_max),
+    )
 
 
 def move_above_food(food=None):

--- a/src/ada_mj/feeding/__init__.py
+++ b/src/ada_mj/feeding/__init__.py
@@ -21,13 +21,13 @@ from ada_mj.feeding.domain import (
     ForkState,
     straight_skewer,
 )
-from ada_mj.feeding.task import feed_bite, feeding_demo
+from ada_mj.feeding.task import feed_bite, feeding_session
 
 __all__ = [
     "AcquisitionSchema",
     "FoodItem",
     "ForkState",
     "feed_bite",
-    "feeding_demo",
+    "feeding_session",
     "straight_skewer",
 ]

--- a/src/ada_mj/feeding/task.py
+++ b/src/ada_mj/feeding/task.py
@@ -175,10 +175,14 @@ def feeding_session(
         immediately on a safety abort.
     """
     succeeded: list[str] = []
-    failed: set[str] = set()
+    failed: list[str] = []
+    attempted: set[str] = set()  # every item tried — the termination guarantee
 
+    # force_replan: don't trust a config cached from a prior session at a
+    # different plate location; solve fresh for the current plate.
     res = observe_plate(
-        robot, ctx, plate_pose=plate_pose, plate_radius=plate_radius, tilt_max=tilt_max
+        robot, ctx, plate_pose=plate_pose, plate_radius=plate_radius,
+        tilt_max=tilt_max, force_replan=True,
     )
     if not res:
         logger.warning("feeding_session: initial observe_plate failed (%s)", res.failure_code)
@@ -186,12 +190,14 @@ def feeding_session(
 
     attempts = 0
     while max_bites is None or attempts < max_bites:
-        # Detect from the observe pose; skip items we already failed to feed so
-        # the loop can't spin forever on an unreachable bite.
-        candidates = [f for f in detect_food() if f.name not in failed]
+        # Each item is attempted at most once: this — not consumption — is what
+        # guarantees termination. A bite that succeeds but isn't actually removed
+        # (consume_food failed, or it's a no-op on hardware) is still not re-fed.
+        candidates = [f for f in detect_food() if f.name not in attempted]
         if not candidates:
             break
         food = candidates[0]
+        attempted.add(food.name)
         attempts += 1
 
         logger.info("feeding_session: feeding %s", food.name)
@@ -203,7 +209,7 @@ def feeding_session(
                 FailureKind.SAFETY_ABORTED,
                 "feeding_session:safety_abort",
                 succeeded=succeeded,
-                failed=sorted(failed),
+                failed=failed,
                 aborted_on=food.name,
             )
 
@@ -216,17 +222,17 @@ def feeding_session(
                 food.name,
                 result.failure_kind.value if result.failure_kind else "unknown",
             )
-            failed.add(food.name)
+            failed.append(food.name)
 
         # Return to the observe pose to re-frame the plate for the next detect.
+        # A failure here can't undo the bites already delivered, so end the
+        # session gracefully with what was achieved rather than reporting failure.
         ret = observe_plate(robot, ctx)
         if not ret:
-            logger.warning("feeding_session: return to observe failed (%s)", ret.failure_code)
-            return failure(
-                FailureKind.EXECUTION_FAILED,
-                "feeding_session:observe_return_failed",
-                succeeded=succeeded,
-                failed=sorted(failed),
+            logger.warning(
+                "feeding_session: return to observe failed (%s) — ending session",
+                ret.failure_code,
             )
+            break
 
-    return success(succeeded=succeeded, failed=sorted(failed))
+    return success(succeeded=succeeded, failed=failed)

--- a/src/ada_mj/feeding/task.py
+++ b/src/ada_mj/feeding/task.py
@@ -23,6 +23,7 @@ from ada_mj.feeding.behaviors import (
     extract_food,
     level_fork,
     move_above,
+    observe_plate,
     retract_from_mouth,
     tare_ft,
     tilt_fork,
@@ -32,6 +33,9 @@ from ada_mj.feeding.behaviors import (
 from ada_mj.feeding.domain import AcquisitionSchema, FoodItem, straight_skewer
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import numpy as np
     from mj_manipulator.protocols import ExecutionContext
 
 logger = logging.getLogger(__name__)
@@ -134,53 +138,95 @@ def feed_bite(
     return success(food=food.name)
 
 
-def feeding_demo(
-    food_items: list[FoodItem],
-    *,
+def feeding_session(
     robot,
     ctx: ExecutionContext,
+    *,
+    detect_food: Callable[[], list[FoodItem]],
+    consume_food: Callable[[FoodItem], None],
+    plate_pose: np.ndarray,
+    plate_radius: float,
+    tilt_max: float = 0.0,
+    max_bites: int | None = None,
 ) -> Outcome:
-    """Run a full feeding session — acquire and deliver each food item.
+    """Run a feeding session: observe → detect → bite → consume → re-observe.
 
-    Continues through the list, skipping items that fail (e.g., can't
-    reach, can't plan). Stops immediately on safety abort.
+    Returns to the ``observe_plate`` staging config (camera framing the whole
+    plate) after every bite and re-detects, so the loop adapts to food that
+    moved or was removed rather than trusting a stale list. Terminates when the
+    plate is clear of food the robot can still attempt.
+
+    Perception and consumption are injected so the same loop runs in sim and on
+    hardware: in sim ``detect_food`` reads on-plate bodies and ``consume_food``
+    hides the eaten one; on hardware they become real perception and a no-op.
 
     Args:
-        food_items: List of food items to feed.
         robot: ADA robot instance.
         ctx: Execution context.
+        detect_food: Returns the food currently on the plate (no args).
+        consume_food: Marks one food item as eaten (removes it from detection).
+        plate_pose: 4x4 world pose of the plate center (for the first observe).
+        plate_radius: Plate radius (m).
+        tilt_max: Look-at cone half-angle for ``observe_plate`` (rad).
+        max_bites: Optional safety cap on the number of bite attempts.
 
     Returns:
-        Outcome with details including which items succeeded/failed.
+        Outcome with ``succeeded`` / ``failed`` food-name lists. Stops
+        immediately on a safety abort.
     """
-    succeeded = []
-    failed = []
+    succeeded: list[str] = []
+    failed: set[str] = set()
 
-    for food in food_items:
-        logger.info("Feeding: %s", food.name)
+    res = observe_plate(
+        robot, ctx, plate_pose=plate_pose, plate_radius=plate_radius, tilt_max=tilt_max
+    )
+    if not res:
+        logger.warning("feeding_session: initial observe_plate failed (%s)", res.failure_code)
+        return res
+
+    attempts = 0
+    while max_bites is None or attempts < max_bites:
+        # Detect from the observe pose; skip items we already failed to feed so
+        # the loop can't spin forever on an unreachable bite.
+        candidates = [f for f in detect_food() if f.name not in failed]
+        if not candidates:
+            break
+        food = candidates[0]
+        attempts += 1
+
+        logger.info("feeding_session: feeding %s", food.name)
         result = feed_bite(food, robot=robot, ctx=ctx)
 
         if result.failure_kind == FailureKind.SAFETY_ABORTED:
-            logger.warning("Safety abort during %s — stopping", food.name)
-            robot.go_to("stow")
-            failed.append(food.name)
+            logger.warning("feeding_session: safety abort during %s — stopping", food.name)
             return failure(
                 FailureKind.SAFETY_ABORTED,
-                "feeding_demo:safety_abort",
+                "feeding_session:safety_abort",
                 succeeded=succeeded,
-                failed=failed,
+                failed=sorted(failed),
                 aborted_on=food.name,
             )
 
         if result:
             succeeded.append(food.name)
+            consume_food(food)
         else:
             logger.warning(
-                "Failed to feed %s (%s) — skipping",
+                "feeding_session: failed to feed %s (%s) — skipping",
                 food.name,
                 result.failure_kind.value if result.failure_kind else "unknown",
             )
-            failed.append(food.name)
+            failed.add(food.name)
 
-    robot.go_to("stow")
-    return success(succeeded=succeeded, failed=failed)
+        # Return to the observe pose to re-frame the plate for the next detect.
+        ret = observe_plate(robot, ctx)
+        if not ret:
+            logger.warning("feeding_session: return to observe failed (%s)", ret.failure_code)
+            return failure(
+                FailureKind.EXECUTION_FAILED,
+                "feeding_session:observe_return_failed",
+                succeeded=succeeded,
+                failed=sorted(failed),
+            )
+
+    return success(succeeded=succeeded, failed=sorted(failed))

--- a/src/ada_mj/scenes/table.py
+++ b/src/ada_mj/scenes/table.py
@@ -41,6 +41,12 @@ PLATE_HEIGHT = 0.027
 # Name of the plate-center site (top surface, z-up) added in _add_table_and_plate.
 PLATE_CENTER_SITE = "plate_center"
 
+# "On the plate" acceptance volume for detect_food: within this horizontal
+# distance of the plate center, and no more than ON_PLATE_Z_DROP below the plate
+# top. Food removed by hide_food (teleported far below) falls outside it.
+ON_PLATE_XY_MARGIN = 1.5 * PLATE_RADIUS
+ON_PLATE_Z_DROP = 0.05
+
 
 def plate_pose(model, data) -> np.ndarray | None:
     """World pose (4x4) of the plate-center site, or ``None`` if absent.
@@ -88,9 +94,9 @@ def detect_food(model, data):
         if not name.startswith("food/"):
             continue
         pos = data.xpos[bid].copy()
-        if np.hypot(pos[0] - center[0], pos[1] - center[1]) > 1.5 * PLATE_RADIUS:
+        if np.hypot(pos[0] - center[0], pos[1] - center[1]) > ON_PLATE_XY_MARGIN:
             continue
-        if pos[2] < center[2] - 0.05:  # below the plate top → hidden/removed
+        if pos[2] < center[2] - ON_PLATE_Z_DROP:  # below the plate top → removed
             continue
         label = name.split("/", 1)[1]
         food_type = label.rsplit("_", 1)[0] if "_" in label else label
@@ -101,12 +107,14 @@ def detect_food(model, data):
 def hide_food(model, data, food_name: str) -> bool:
     """Remove an eaten food body from the scene (sim stand-in for consumption).
 
-    Teleports the food's freejoint far below the floor, zeros its velocity, and
-    disables its contacts so it neither renders on the plate nor interferes with
-    physics. After this, :func:`detect_food` no longer returns it. On hardware
-    this is a no-op — the eaten bite is simply gone from perception.
+    Teleports the food's freejoint far below the floor and zeros its velocity.
+    That position is below the floor and outside :func:`detect_food`'s on-plate
+    window, so the body no longer renders on the plate nor is re-detected. On
+    hardware this is a no-op — the eaten bite is simply gone from perception.
 
-    Must run on the thread that owns ``data``.
+    Only ``data`` is mutated (not ``model``), so a later ``mj_resetData`` /
+    keyframe reset restores the food cleanly. Must run on the thread that owns
+    ``data``.
 
     Returns:
         True if the body was found and hidden.
@@ -119,11 +127,6 @@ def hide_food(model, data, food_name: str) -> bool:
     data.qpos[qadr + 3 : qadr + 7] = [1.0, 0.0, 0.0, 0.0]
     vadr = model.jnt_dofadr[jid]
     data.qvel[vadr : vadr + 6] = 0.0
-    bid = model.jnt_bodyid[jid]
-    for g in range(model.body_geomnum[bid]):
-        gid = model.body_geomadr[bid] + g
-        model.geom_contype[gid] = 0
-        model.geom_conaffinity[gid] = 0
     mujoco.mj_forward(model, data)
     return True
 

--- a/src/ada_mj/scenes/table.py
+++ b/src/ada_mj/scenes/table.py
@@ -17,13 +17,11 @@ items are freejoint so the fork can stab and lift them.
 
 from __future__ import annotations
 
-import numpy as np
 import mujoco
-
+import numpy as np
 from ada_assets.assembly import build_spec, compile_and_init
 from prl_assets import OBJECTS_DIR
 from tsr.placement.stable_placer import StablePlacer
-
 
 # Table position in the wheelchair/world frame. x and y are derived from
 # the ada_feeding planning scene (config: ada_planning_scene.yaml, namespace
@@ -61,6 +59,73 @@ def plate_pose(model, data) -> np.ndarray | None:
     T[:3, :3] = data.site_xmat[sid].reshape(3, 3)
     T[:3, 3] = data.site_xpos[sid]
     return T
+
+
+def detect_food(model, data):
+    """Food items currently *on the plate* (the sim stand-in for perception).
+
+    Reads ``food/*`` bodies from live MuJoCo state and keeps those resting on
+    the plate — within ``1.5·PLATE_RADIUS`` horizontally of the plate center and
+    not below it. Food removed by :func:`hide_food` (teleported far below) is
+    naturally excluded, exactly as a real perception pipeline would stop seeing
+    an eaten bite. On hardware this function is replaced by camera + segmentation.
+
+    Must run on the thread that owns ``data`` (it calls ``mj_forward``).
+
+    Returns:
+        List of :class:`~ada_mj.feeding.domain.FoodItem`.
+    """
+    from ada_mj.feeding.domain import FoodItem
+
+    plate = plate_pose(model, data)  # also runs mj_forward
+    if plate is None:
+        return []
+    center = plate[:3, 3]
+
+    items = []
+    for bid in range(model.nbody):
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, bid) or ""
+        if not name.startswith("food/"):
+            continue
+        pos = data.xpos[bid].copy()
+        if np.hypot(pos[0] - center[0], pos[1] - center[1]) > 1.5 * PLATE_RADIUS:
+            continue
+        if pos[2] < center[2] - 0.05:  # below the plate top → hidden/removed
+            continue
+        label = name.split("/", 1)[1]
+        food_type = label.rsplit("_", 1)[0] if "_" in label else label
+        items.append(FoodItem(name=name, position=pos, food_type=food_type))
+    return items
+
+
+def hide_food(model, data, food_name: str) -> bool:
+    """Remove an eaten food body from the scene (sim stand-in for consumption).
+
+    Teleports the food's freejoint far below the floor, zeros its velocity, and
+    disables its contacts so it neither renders on the plate nor interferes with
+    physics. After this, :func:`detect_food` no longer returns it. On hardware
+    this is a no-op — the eaten bite is simply gone from perception.
+
+    Must run on the thread that owns ``data``.
+
+    Returns:
+        True if the body was found and hidden.
+    """
+    jid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, f"{food_name}/freejoint")
+    if jid < 0:
+        return False
+    qadr = model.jnt_qposadr[jid]
+    data.qpos[qadr : qadr + 3] = [0.0, 0.0, -10.0]
+    data.qpos[qadr + 3 : qadr + 7] = [1.0, 0.0, 0.0, 0.0]
+    vadr = model.jnt_dofadr[jid]
+    data.qvel[vadr : vadr + 6] = 0.0
+    bid = model.jnt_bodyid[jid]
+    for g in range(model.body_geomnum[bid]):
+        gid = model.body_geomadr[bid] + g
+        model.geom_contype[gid] = 0
+        model.geom_conaffinity[gid] = 0
+    mujoco.mj_forward(model, data)
+    return True
 
 # Usable half-extents of the table surface for placement sampling.
 # The table mesh is 1.85 × 0.74 m but the C-shape leaves a smaller usable

--- a/tests/test_feeding_session.py
+++ b/tests/test_feeding_session.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Tests for the feeding_session loop (observe → detect → bite → consume).
+
+The loop logic is tested in isolation from feed_bite/observe_plate (which are
+gated on separate motion blockers) by monkeypatching them: this catches loop
+bugs — non-termination, consuming on failure, not skipping a failed item,
+mishandling a safety abort — that the full pipeline would hide.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from mj_manipulator.outcome import FailureKind, failure, success
+
+import ada_mj.feeding.task as task
+from ada_mj.feeding.domain import FoodItem
+
+
+def _foods(n):
+    return [
+        FoodItem(name=f"food/x_{i}", position=np.zeros(3), food_type="x")
+        for i in range(n)
+    ]
+
+
+def _run(monkeypatch, *, feed_bite_result, foods, consume_removes=True, max_bites=None):
+    """Drive feeding_session with stubbed observe/feed and a mutable plate.
+
+    Returns (outcome, remaining_names, consumed_names).
+    """
+    remaining = {f.name: f for f in foods}
+    consumed = []
+
+    monkeypatch.setattr(task, "observe_plate", lambda *a, **k: success())
+    monkeypatch.setattr(task, "feed_bite", lambda food, **k: feed_bite_result(food))
+
+    def detect():
+        return list(remaining.values())
+
+    def consume(f):
+        consumed.append(f.name)
+        if consume_removes:
+            remaining.pop(f.name, None)
+
+    outcome = task.feeding_session(
+        robot=object(),
+        ctx=object(),
+        detect_food=detect,
+        consume_food=consume,
+        plate_pose=np.eye(4),
+        plate_radius=0.1,
+        max_bites=max_bites,
+    )
+    return outcome, set(remaining), consumed
+
+
+def test_session_eats_and_consumes_all(monkeypatch):
+    foods = _foods(3)
+    outcome, remaining, consumed = _run(
+        monkeypatch, feed_bite_result=lambda f: success(food=f.name), foods=foods
+    )
+    assert outcome
+    assert sorted(outcome.details["succeeded"]) == [f.name for f in foods]
+    assert sorted(consumed) == [f.name for f in foods]
+    assert remaining == set()  # plate cleared → loop terminated
+
+
+def test_session_skips_failed_items_and_terminates(monkeypatch):
+    """A non-safety failure must skip the item (not consume) and still halt."""
+    foods = _foods(2)
+    outcome, remaining, consumed = _run(
+        monkeypatch,
+        feed_bite_result=lambda f: failure(FailureKind.PLANNING_FAILED, "x:no_path"),
+        foods=foods,
+        max_bites=10,  # guard: test fails loudly if the loop spins instead of skipping
+    )
+    assert outcome  # session completed (didn't hang)
+    assert sorted(outcome.details["failed"]) == [f.name for f in foods]
+    assert consumed == []  # failures are never consumed
+    assert remaining == {f.name for f in foods}  # food untouched on the plate
+
+
+def test_session_safety_abort_stops_immediately(monkeypatch):
+    foods = _foods(3)
+    outcome, remaining, consumed = _run(
+        monkeypatch,
+        feed_bite_result=lambda f: failure(FailureKind.SAFETY_ABORTED, "x:estop"),
+        foods=foods,
+    )
+    assert not outcome
+    assert outcome.failure_kind == FailureKind.SAFETY_ABORTED
+    assert outcome.details["aborted_on"] == foods[0].name
+    assert consumed == []
+
+
+def test_session_respects_max_bites(monkeypatch):
+    foods = _foods(5)
+    outcome, remaining, consumed = _run(
+        monkeypatch,
+        feed_bite_result=lambda f: success(food=f.name),
+        foods=foods,
+        max_bites=2,
+    )
+    assert outcome
+    assert len(consumed) == 2  # stopped at the cap, plate not cleared
+    assert len(remaining) == 3
+
+
+def test_session_aborts_if_initial_observe_fails(monkeypatch):
+    monkeypatch.setattr(
+        task, "observe_plate", lambda *a, **k: failure(FailureKind.PLANNING_FAILED, "o:no_path")
+    )
+    monkeypatch.setattr(task, "feed_bite", lambda food, **k: success())
+    called = []
+    outcome = task.feeding_session(
+        robot=object(),
+        ctx=object(),
+        detect_food=lambda: called.append(1) or _foods(1),
+        consume_food=lambda f: None,
+        plate_pose=np.eye(4),
+        plate_radius=0.1,
+    )
+    assert not outcome
+    assert called == []  # never reached detection — bailed on the first observe
+
+
+@pytest.mark.slow
+def test_detect_and_hide_food_in_sim():
+    """detect_food / hide_food mechanics against the real table scene."""
+    import mujoco
+
+    from ada_mj.config import ADAConfig
+    from ada_mj.scenes.table import detect_food, hide_food
+
+    ADA = pytest.importorskip("ada_mj.robot").ADA
+    robot = ADA(ADAConfig.default())
+    mujoco.mj_forward(robot.model, robot.data)
+
+    foods = detect_food(robot.model, robot.data)
+    n0 = len(foods)
+    assert n0 >= 1
+
+    assert hide_food(robot.model, robot.data, foods[0].name)
+    remaining = detect_food(robot.model, robot.data)
+    assert len(remaining) == n0 - 1
+    assert foods[0].name not in {f.name for f in remaining}
+    assert not hide_food(robot.model, robot.data, "food/nonexistent_99")
+
+
+@pytest.mark.slow
+def test_session_clears_plate_in_sim(monkeypatch):
+    """Acceptance: real observe → detect → (stubbed bite) → hide → re-observe
+    clears the plate and terminates. Only feed_bite is stubbed — it is gated on
+    separate motion blockers — so this exercises the real loop integration:
+    observe_plate plans/executes between every bite, detect/hide mutate live
+    state, and the loop drives to an empty plate.
+    """
+    import mujoco
+
+    from ada_mj.config import ADAConfig
+    from ada_mj.scenes.table import PLATE_RADIUS, detect_food, hide_food, plate_pose
+
+    ADA = pytest.importorskip("ada_mj.robot").ADA
+    robot = ADA(ADAConfig.default())
+    monkeypatch.setattr(task, "feed_bite", lambda food, **k: success(food=food.name))
+
+    with robot.sim(physics=False, headless=True) as ctx:
+        robot.arm.set_joint_positions(robot.named_poses["above_plate"])
+        robot._snap_tool_to_weld()
+        mujoco.mj_forward(robot.model, robot.data)
+        pose = plate_pose(robot.model, robot.data)
+        n0 = len(detect_food(robot.model, robot.data))
+        outcome = task.feeding_session(
+            robot,
+            ctx,
+            detect_food=lambda: detect_food(robot.model, robot.data),
+            consume_food=lambda f: hide_food(robot.model, robot.data, f.name),
+            plate_pose=pose,
+            plate_radius=PLATE_RADIUS,
+        )
+        assert outcome, f"session failed: {outcome.failure_code}"
+        assert len(outcome.details["succeeded"]) == n0
+        assert detect_food(robot.model, robot.data) == []  # plate cleared

--- a/tests/test_feeding_session.py
+++ b/tests/test_feeding_session.py
@@ -127,6 +127,61 @@ def test_session_aborts_if_initial_observe_fails(monkeypatch):
     assert called == []  # never reached detection — bailed on the first observe
 
 
+def test_session_terminates_when_consume_is_noop(monkeypatch):
+    """A successful bite that isn't actually removed must not be re-fed.
+
+    consume_food is a no-op (the hardware case, or a hide that silently fails),
+    so detect keeps returning every item. The attempted-set — not consumption —
+    must still guarantee each item is fed exactly once and the loop terminates.
+    Without that guard this would be an infinite loop.
+    """
+    foods = _foods(3)
+    outcome, remaining, consumed = _run(
+        monkeypatch,
+        feed_bite_result=lambda f: success(food=f.name),
+        foods=foods,
+        consume_removes=False,  # consume does nothing — detect always returns all
+        max_bites=10,  # guard: a regression hits the cap instead of hanging the suite
+    )
+    assert outcome
+    assert sorted(outcome.details["succeeded"]) == [f.name for f in foods]  # each once
+    assert len(outcome.details["succeeded"]) == 3
+    assert remaining == {f.name for f in foods}  # never removed, yet never re-fed
+
+
+def test_session_soft_ends_on_observe_return_failure(monkeypatch):
+    """A return-to-observe failure ends the session gracefully — the bites that
+    were already delivered stand (success), not a hard failure."""
+    foods = _foods(3)
+    remaining = {f.name: f for f in foods}
+    consumed = []
+    calls = {"n": 0}
+
+    def observe(*a, **k):
+        calls["n"] += 1
+        # initial observe succeeds; the return after the first bite fails
+        return success() if calls["n"] == 1 else failure(FailureKind.PLANNING_FAILED, "o:no_path")
+
+    def consume(f):
+        consumed.append(f.name)
+        remaining.pop(f.name, None)
+
+    monkeypatch.setattr(task, "observe_plate", observe)
+    monkeypatch.setattr(task, "feed_bite", lambda food, **k: success(food=food.name))
+
+    outcome = task.feeding_session(
+        robot=object(),
+        ctx=object(),
+        detect_food=lambda: list(remaining.values()),
+        consume_food=consume,
+        plate_pose=np.eye(4),
+        plate_radius=0.1,
+    )
+    assert outcome  # success despite the observe-return failure
+    assert outcome.details["succeeded"] == [foods[0].name]  # one delivered, then ended
+    assert consumed == [foods[0].name]
+
+
 @pytest.mark.slow
 def test_detect_and_hide_food_in_sim():
     """detect_food / hide_food mechanics against the real table scene."""


### PR DESCRIPTION
Slice 2 of #42 (builds on the merged Slice 1, #43).

## What
Replaces the fixed-list `feeding_demo` with a sense-plan-act loop that returns to the `observe_plate` staging config (camera framing the whole plate) after every bite and **re-detects** — adapting to food that moved or was removed instead of trusting a stale list.

```
observe_plate → detect → feed_bite → consume → re-observe → … until plate clear
```

- **`feeding_session` (task.py)** — pure orchestration. Perception (`detect_food`) and consumption (`consume_food`) are **injected**, so the identical loop runs in sim and on hardware (hardware supplies real perception + a no-op consume). A failed non-safety bite is skipped (not consumed) and excluded from reselection so the loop can't spin; a safety abort stops immediately.
- **`scenes/table.py`** — `detect_food()` returns on-plate `food/*` bodies (sim perception stand-in); `hide_food()` teleports an eaten body below the floor + disables its contacts (sim consumption stand-in). They compose: a hidden body is no longer detected, exactly as real perception stops seeing an eaten bite.
- **`demos/feeding.py`** — `feed_all()` wires the sim detect/hide into `feeding_session`, marshaling live-state reads/writes onto the data-owning thread via the event loop; `food_items()` now reports only on-plate food.

## Why injected perception/consumption
Keeps `task.py` scene- and threading-agnostic and preserves sim-to-real parity: the loop never imports mujoco or knows about the table scene; the demo (or a hardware node) provides the implementations.

## Verification
- **5 fast loop-logic tests** (feed_bite/observe stubbed to isolate the loop): eats+consumes all and terminates; skips failures without spinning (guarded by max_bites); safety abort stops; max_bites respected; initial-observe failure bails before detecting.
- **2 slow integration tests**: detect/hide mechanics against the real scene, and the **acceptance test** where real `observe_plate` planning between every bite + real detect/hide drives the plate to empty.
- 30 tests pass total; ruff clean on new files.

## Not in this slice
`feed_bite` itself is unchanged and still gated on the motion blockers (#28 tilt-settle, #34 level_fork, #36 mouth servo) — that's why the acceptance test stubs `feed_bite`. This slice delivers and proves the loop structure + consumption.

Part of #42.